### PR TITLE
Combine class and style attributes

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -54,30 +54,29 @@ pub fn map(attr: Attribute(a), f: fn(a) -> b) -> Attribute(b) {
 
 ///
 /// 
-pub fn to_string_parts(attr: Attribute(msg)) -> Option(#(String, String)) {
+pub fn to_string_parts(
+  attr: Attribute(msg),
+) -> Option(#(String, Option(String))) {
   case attr {
     Attribute(name, value, as_property: False) -> {
       case dynamic.classify(value) {
-        "String" -> Some(#(name, dynamic.unsafe_coerce(value)))
+        "String" -> Some(#(name, Some(dynamic.unsafe_coerce(value))))
 
         // Boolean attributes are determined based on their presence, eg we don't
         // want to render `disabled="false"` if the value is `false` we simply
         // want to omit the attribute altogether.
-        "Boolean" -> {
-          let value = case dynamic.unsafe_coerce(value) {
-            True -> name
-            False -> ""
+        "Boolean" ->
+          case dynamic.unsafe_coerce(value) {
+            True -> Some(#(name, None))
+            False -> None
           }
 
-          Some(#(name, value))
-        }
-
         // For everything else we'll just make a best-effort serialisation. 
-        _ -> Some(#(name, string.inspect(value)))
+        _ -> Some(#(name, Some(string.inspect(value))))
       }
     }
     Attribute(_, _, as_property: True) -> None
-    Event(on, _) -> Some(#("data-lustre-on", on))
+    Event(on, _) -> Some(#("data-lustre-on", Some(on)))
   }
 }
 

--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -146,12 +146,17 @@ fn attrs_to_string_builder(
     use #(html, class, style), attr <- list.fold(attrs, #(html, "", ""))
 
     case attribute.to_string_parts(attr) {
-      Some(#("class", val)) if class == "" -> #(html, val, style)
-      Some(#("class", val)) -> #(html, class <> " " <> val, style)
-      Some(#("style", val)) if style == "" -> #(html, class, val)
-      Some(#("style", val)) -> #(html, class, style <> " " <> val)
-      Some(#(key, val)) -> #(
+      Some(#("class", Some(val))) if class == "" -> #(html, val, style)
+      Some(#("class", Some(val))) -> #(html, class <> " " <> val, style)
+      Some(#("style", Some(val))) if style == "" -> #(html, class, val)
+      Some(#("style", Some(val))) -> #(html, class, style <> " " <> val)
+      Some(#(key, Some(val))) -> #(
         string_builder.append(html, " " <> key <> "=\"" <> val <> "\""),
+        class,
+        style,
+      )
+      Some(#(key, None)) -> #(
+        string_builder.append(html, " " <> key),
         class,
         style,
       )
@@ -161,12 +166,12 @@ fn attrs_to_string_builder(
 
   case class, style {
     "", "" -> html
-    _, "" -> string_builder.append(html, "class=\"" <> class <> "\"")
-    "", _ -> string_builder.append(html, "style=\"" <> style <> "\"")
+    _, "" -> string_builder.append(html, " class=\"" <> class <> "\"")
+    "", _ -> string_builder.append(html, " style=\"" <> style <> "\"")
     _, _ ->
       string_builder.append(
         html,
-        "class=\"" <> class <> "\" style=\"" <> style <> "\"",
+        " class=\"" <> class <> "\" style=\"" <> style <> "\"",
       )
   }
 }

--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -141,7 +141,7 @@ fn attrs_to_string_builder(
   html: StringBuilder,
   attrs: List(Attribute(msg)),
 ) -> StringBuilder {
-  use html, attr <- list.fold(attrs, html)
+  use html, attr <- list.fold(attribute.combine(attrs), html)
   html
   |> string_builder.append(" ")
   |> string_builder.append_builder(attribute.to_string_builder(attr))

--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -4,6 +4,7 @@
 // IMPORTS ---------------------------------------------------------------------
 
 import gleam/list
+import gleam/option.{None, Some}
 import gleam/string
 import gleam/string_builder.{StringBuilder}
 import lustre/attribute.{Attribute}
@@ -141,10 +142,33 @@ fn attrs_to_string_builder(
   html: StringBuilder,
   attrs: List(Attribute(msg)),
 ) -> StringBuilder {
-  use html, attr <- list.fold(attribute.combine(attrs), html)
-  html
-  |> string_builder.append(" ")
-  |> string_builder.append_builder(attribute.to_string_builder(attr))
+  let #(html, class, style) = {
+    use #(html, class, style), attr <- list.fold(attrs, #(html, "", ""))
+
+    case attribute.to_string_parts(attr) {
+      Some(#("class", val)) if class == "" -> #(html, val, style)
+      Some(#("class", val)) -> #(html, class <> " " <> val, style)
+      Some(#("style", val)) if style == "" -> #(html, class, val)
+      Some(#("style", val)) -> #(html, class, style <> " " <> val)
+      Some(#(key, val)) -> #(
+        string_builder.append(html, " " <> key <> "=\"" <> val <> "\""),
+        class,
+        style,
+      )
+      None -> #(html, class, style)
+    }
+  }
+
+  case class, style {
+    "", "" -> html
+    _, "" -> string_builder.append(html, "class=\"" <> class <> "\"")
+    "", _ -> string_builder.append(html, "style=\"" <> style <> "\"")
+    _, _ ->
+      string_builder.append(
+        html,
+        "class=\"" <> class <> "\" style=\"" <> style <> "\"",
+      )
+  }
 }
 
 fn children_to_string_builder(


### PR DESCRIPTION
Fixes #12, class and style attributes are no longer duplicated in statically generated html.

Renames `to_string` to `to_string_parts` in src/lustre/attribute.gleam, and changes return type from `String` to `Option(#(String, String))`.

Also updates `attrs_to_string_builder` to handle this change.