### PR TITLE
docs: Fix small typo in README example so that it works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ import lustre/event.{on_click}
 
 pub fn main() {
   let app = lustre.simple(init, update, view)
-  let assert Ok(_) = lustre.start("[data-lustre-app]", Nil)
+  let assert Ok(_) = lustre.start(app, "[data-lustre-app]", Nil)
 
   Nil
 }


### PR DESCRIPTION
I tried running the example in the README, and realized that `app` was missing from `lustre.start`.