### PR TITLE
🐛 Fixed a bug where lustre/try crashes on 404 (javascript target)

### DIFF
--- a/src/http.ffi.mjs
+++ b/src/http.ffi.mjs
@@ -47,9 +47,9 @@ const server = Http.createServer((req, res) => {
           res.statusCode = 200;
           res.end(src);
         })
-        .catch((err) => {
+        .catch((_err) => {
           res.statusCode = 404;
-          res.end(err);
+          res.end();
         });
 
       break;
@@ -62,9 +62,9 @@ const server = Http.createServer((req, res) => {
           res.statusCode = 200;
           res.end(src);
         })
-        .catch((err) => {
+        .catch((_err) => {
           res.statusCode = 404;
-          res.end(err);
+          res.end();
         });
 
       break;
@@ -77,9 +77,9 @@ const server = Http.createServer((req, res) => {
           res.statusCode = 200;
           res.end(src);
         })
-        .catch((err) => {
+        .catch((_err) => {
           res.statusCode = 404;
-          res.end(err);
+          res.end();
         });
     }
   }


### PR DESCRIPTION
Some browsers would try loading favicon which causes a 404 Not Found error, craching the Http server:

```shell
$ gleam run -m lustre/try --target javascript
   Compiled in 0.04s
    Running lustre/try.main
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Error
    at new NodeError (node:internal/errors:405:5)
    at write_ (node:_http_outgoing:875:11)
    at ServerResponse.end (node:_http_outgoing:1026:5)
    at file:///D:/github/lustre_ui/demo/build/dev/javascript/lustre/http.ffi.mjs:82:15 {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

This PR fixes it.