### PR TITLE
Add logging to `lustre/try`

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -16,3 +16,4 @@ internal_modules = [
 
 [dependencies]
 gleam_stdlib = "~> 0.34"
+gleam_community_ansi = "~> 1.3"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,11 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_community_ansi", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "AB7C3CCC894653637E02DC455D5890C8CF3064E83E78CFE61145A4C458D02DE6" },
+  { name = "gleam_community_colour", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "A49A5E3AE8B637A5ACBA80ECB9B1AFE89FD3D5351FF6410A42B84F666D40D7D5" },
   { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
 ]
 
 [requirements]
+gleam_community_ansi = { version = "~> 1.3" }
 gleam_stdlib = { version = "~> 0.34" }

--- a/src/http.ffi.mjs
+++ b/src/http.ffi.mjs
@@ -85,6 +85,17 @@ const server = Http.createServer((req, res) => {
   }
 });
 
-export const serve = (host, port, on_start) => {
-  server.listen(port, host, on_start);
+export const serve = (host, port, on_start, on_port_taken) => {
+  let tries = 1;
+  server.on("error", (error) => {
+    if (error.code === "EADDRINUSE") {
+      let is_first_try = tries === 1;
+      if (is_first_try) {
+        on_port_taken(port);
+      }
+      tries++;
+      port++;
+      server.listen(port, host);
+    }
+  }).listen(port, host, () => { on_start(port) });
 };

--- a/src/http.ffi.mjs
+++ b/src/http.ffi.mjs
@@ -85,6 +85,6 @@ const server = Http.createServer((req, res) => {
   }
 });
 
-export const serve = (port) => {
-  server.listen(port, "localhost");
+export const serve = (host, port, on_start) => {
+  server.listen(port, host, on_start);
 };

--- a/src/http_ffi.erl
+++ b/src/http_ffi.erl
@@ -1,7 +1,7 @@
 -module(http_ffi).
--export([serve/1]).
+-export([serve/3]).
 
-serve(Port) ->
+serve(Host, Port, OnStart) ->
     {ok, Pattern} = re:compile("name *= *\"(?<Name>.+)\""),
     {ok, Toml} = file:read_file("gleam.toml"),
     {match, [Name]} = re:run(Toml, Pattern, [{capture, all_names, binary}]),
@@ -49,12 +49,14 @@ serve(Port) ->
             {document_root, AbsPath},
             {server_root, AbsPath},
             {directory_index, ["index.html"]},
-            {server_name, "localhost"},
+            {server_name, binary_to_list(Host)},
             {port, Port},
             {default_type, "text/html"},
             {mime_types, mime_types()},
             {modules, [mod_alias, mod_dir, mod_get]}
         ]),
+
+    OnStart(),
 
     receive
         {From, shutdown} ->

--- a/src/lustre/try.gleam
+++ b/src/lustre/try.gleam
@@ -6,13 +6,27 @@ pub fn main() {
   let host = "localhost"
   let port = 1234
 
-  let address = "http://" <> host <> ":" <> int.to_string(port)
-
-  serve(host, port, fn() {
+  let on_start = fn(actual_port) {
+    let address = "http://" <> host <> ":" <> int.to_string(actual_port)
     io.println("✨ Server has been started at " <> ansi.bold(address))
-  })
+  }
+
+  let on_port_taken = fn(taken_port) {
+    io.println(
+      "🚨 Port "
+      <> ansi.bold(int.to_string(taken_port))
+      <> " already in use, using next available port",
+    )
+  }
+
+  serve(host, port, on_start, on_port_taken)
 }
 
 @external(erlang, "http_ffi", "serve")
 @external(javascript, "../http.ffi.mjs", "serve")
-fn serve(host: String, port: Int, on_start: fn() -> Nil) -> Nil
+fn serve(
+  host: String,
+  port: Int,
+  on_start: fn(Int) -> Nil,
+  on_port_taken: fn(Int) -> Nil,
+) -> Nil

--- a/src/lustre/try.gleam
+++ b/src/lustre/try.gleam
@@ -1,7 +1,18 @@
+import gleam/int
+import gleam/io
+import gleam_community/ansi
+
 pub fn main() {
-  serve(1234)
+  let host = "localhost"
+  let port = 1234
+
+  let address = "http://" <> host <> ":" <> int.to_string(port)
+
+  serve(host, port, fn() {
+    io.println("✨ Server has been started at " <> ansi.bold(address))
+  })
 }
 
 @external(erlang, "http_ffi", "serve")
 @external(javascript, "../http.ffi.mjs", "serve")
-fn serve(port: Int) -> Nil
+fn serve(host: String, port: Int, on_start: fn() -> Nil) -> Nil


### PR DESCRIPTION
This PR closes #25 

- [X] Add log message when the server is started
- [x] Add warning when server starts on a different port, this would require:
  - [x] Make server start on the first available port