### PR TITLE
Fix `autofocus` property name

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -143,7 +143,7 @@ pub fn autocomplete(name: String) -> Attribute(msg) {
 
 ///
 pub fn autofocus(should_autofocus: Bool) -> Attribute(msg) {
-  property("autoFocus", should_autofocus)
+  property("autofocus", should_autofocus)
 }
 
 ///


### PR DESCRIPTION
This PR fixes (what appears to be) a bug in the `autofocus` attribute.

I'm still not quite clear on the differences between properties and attributes, so it's possible I've misunderstood something 😅

Here is what I ran into:

When using `autofocus(True)` I don't see the `autofocus` attribute being applied to the `div` in the DOM:

```gleam
div([autofocus(True)], [])
```

However, if I apply it manually and use `"autofocus"` instead of `"autoFocus"` then it works as expected:

```gleam
div([property("autofocus", True)], [])
```
