### PR TITLE
Update readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ fn view(model) {
   let count = int.to_string(model)
 
   div([], [
-    button([on_click(Decr)], [text(" + ")]),
+    button([on_click(Incr)], [text(" + ")]),
     p([], [text(count)]),
-    button([on_click(Incr)], [text(" - ")])
+    button([on_click(Decr)], [text(" - ")])
   ])
 }
 ```


### PR DESCRIPTION
This PR addresses a minor mixup in the README that incorrectly swaps the `Incr` and `Decr` messages. Copy/pasting this issue would have the `+` decrement the value and the `-` increment the value.