### PR TITLE
feat: add form-related attributes

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -287,3 +287,50 @@ pub fn controls(visible: Bool) -> Attribute(msg) {
 pub fn loop(should_loop: Bool) -> Attribute(msg) {
   property("loop", should_loop)
 }
+
+// FORMS -----------------------------------------------------------------------
+
+///
+pub fn action(url: String) -> Attribute(msg) {
+  attribute("action", url)
+}
+
+///
+pub fn enctype(value: String) -> Attribute(msg) {
+  attribute("enctype", value)
+}
+
+///
+pub fn method(method: String) -> Attribute(msg) {
+  attribute("method", method)
+}
+
+///
+pub fn novalidate(value: Bool) -> Attribute(msg) {
+  property("novalidate", value)
+}
+
+///
+pub fn formaction(action: String) -> Attribute(msg) {
+  attribute("formaction", action)
+}
+
+///
+pub fn formenctype(value: String) -> Attribute(msg) {
+  attribute("formenctype", value)
+}
+
+///
+pub fn formmethod(method: String) -> Attribute(msg) {
+  attribute("formmethod", method)
+}
+
+///
+pub fn formnovalidate(value: Bool) -> Attribute(msg) {
+  property("formnovalidate", value)
+}
+
+///
+pub fn formtarget(target: String) -> Attribute(msg) {
+  attribute("formtarget", target)
+}


### PR DESCRIPTION
Adds various attributes related to form submission, based on the attributes listed by the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attributes_for_form_submission).

Note that the `target` attribute was already defined in the "links and areas" section of `attribute.gleam`.