### PR TITLE
Fix link to Quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ end
 
 ## Where next
 
-To get up to speed with Lustre, check out the [quickstart guide](https://hexdocs.pm/lustre/4.0.0-rc1/guide/01-quickstart).
+To get up to speed with Lustre, check out the [quickstart guide](https://hexdocs.pm/lustre/4.0.0-rc1/guide/01-quickstart.html).
 If you prefer to see some code, the [examples](https://github.com/lustre-labs/lustre/tree/main/examples)
 directory contains a handful of small applications that demonstrate different
 aspects of the framework.


### PR DESCRIPTION
Original link was a 404