### PR TITLE
Add support for linux aarch64 esbuild

### DIFF
--- a/src/lustre/cli/esbuild.gleam
+++ b/src/lustre/cli/esbuild.gleam
@@ -118,6 +118,7 @@ fn get_download_url(os, cpu) {
     "freebsd", "arm64" -> Ok("freebsd-arm64/-/freebsd-arm64-0.19.10.tgz")
     "freebsd", "x64" -> Ok("freebsd-x64/-/freebsd-x64-0.19.10.tgz")
 
+    "linux", "aarch64" -> Ok("linux-arm64/-/linux-arm64-0.19.10.tgz")
     "linux", "arm" -> Ok("linux-arm/-/linux-arm-0.19.10.tgz")
     "linux", "arm64" -> Ok("linux-arm64/-/linux-arm64-0.19.10.tgz")
     "linux", "ia32" -> Ok("linux-ia32/-/linux-ia32-0.19.10.tgz")
@@ -209,8 +210,8 @@ There was a network error!",
     // TODO: this could give a better error for some common reason like Enoent.
     SimplifileError(reason, path) -> io.println("
 I ran into the following error at path `" <> path <> "`:" <> string.inspect(
-          reason,
-        ) <> ".")
+        reason,
+      ) <> ".")
 
     UnknownPlatform(os, cpu) -> io.println("
 I couldn't figure out the correct esbuild version for your


### PR DESCRIPTION
I'm trying to run `gleam run -m lustre build app` inside of a linux docker container on an M1 Macbook.  However, it prints the following statement and exits:
```
I couldn't figure out the correct esbuild version for your
os (linux) and cpu (aarch64)
```

Looking at the [official esbuild download script](https://github.com/evanw/esbuild/blob/main/dl.sh) it looks like they download the `arm64` version for `aarch64` architectures.

I've added a download case based on the same idea.