### PR TITLE
Fix stringifying dangerous HTML attribute

### DIFF
--- a/src/lustre/internals/vdom.gleam
+++ b/src/lustre/internals/vdom.gleam
@@ -324,7 +324,6 @@ fn attribute_to_string_parts(
 ) -> Result(#(String, String), Nil) {
   case attr {
     Attribute("", _, _) -> Error(Nil)
-    Attribute("dangerous-unescaped-html", _, _) -> Error(Nil)
     Attribute(name, value, as_property) -> {
       let true_atom = dynamic.from(True)
 


### PR DESCRIPTION
As per our Discord discussion. This makes dangerous inner HTML appear when `element.to_string` is used.

This was tested with a path dep on RC2.