### PR TITLE
#16 add fragment

### DIFF
--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -12,7 +12,7 @@ import gleam/list
 import gleam/string
 import gleam/string_builder.{type StringBuilder}
 import lustre/attribute.{type Attribute, attribute}
-import lustre/internals/vdom.{Element, Map, Text}
+import lustre/internals/vdom.{Element, Fragment, Map, Text}
 
 // TYPES -----------------------------------------------------------------------
 
@@ -176,6 +176,12 @@ pub fn none() -> Element(msg) {
   Text("")
 }
 
+/// A function to wrap multiple elements to be rendered without wrapping them in a container
+/// 
+pub fn fragment(elements: List(Element(msg))) -> Element(msg) {
+  vdom.fragment(elements)
+}
+
 fn escape(escaped: String, content: String) -> String {
   case content {
     "<" <> rest -> escape(escaped <> "&lt;", rest)
@@ -215,6 +221,9 @@ pub fn map(element: Element(a), f: fn(a) -> b) -> Element(b) {
           void: void,
         )
       })
+    Fragment(identifier, elements) -> {
+      Map(fn() { Fragment(identifier, list.map(elements, map(_, f))) })
+    }
   }
 }
 

--- a/src/lustre/internals/patch.gleam
+++ b/src/lustre/internals/patch.gleam
@@ -11,7 +11,7 @@ import gleam/set.{type Set}
 import gleam/string
 import lustre/internals/constants
 import lustre/internals/vdom.{
-  type Attribute, type Element, Attribute, Element, Event, Map, Text,
+  type Attribute, type Element, Attribute, Element, Event, Fragment, Map, Text,
 }
 
 // TYPES -----------------------------------------------------------------------
@@ -124,13 +124,7 @@ fn do_elements(
               handlers: handlers,
             )
 
-          // This local `zip` function takes two lists of potentially different
-          // sizes and zips them together, padding the shorter list with `None`.
-          let children = zip(old_children, new_children)
-          use diff, #(old, new), pos <- list.index_fold(children, diff)
-          let key = key <> int.to_string(pos)
-
-          do_elements(diff, old, new, key)
+          do_element_list(diff, old_children, new_children, key)
         }
 
         // When we have two elements, but their namespaces or their tags differ,
@@ -142,9 +136,33 @@ fn do_elements(
             created: dict.insert(diff.created, key, new),
             handlers: fold_event_handlers(diff.handlers, new, key),
           )
+        Fragment(_, old_elements), Fragment(_, new_elements) ->
+          do_element_list(diff, old_elements, new_elements, key)
+        // Other element is not a fragment, take new element in both cases
+        _, Fragment(_, _) | Fragment(_, _), _ ->
+          ElementDiff(
+            ..diff,
+            created: dict.insert(diff.created, key, new),
+            handlers: fold_event_handlers(diff.handlers, new, key),
+          )
       }
     }
   }
+}
+
+fn do_element_list(
+  diff: ElementDiff(msg),
+  old_elements: List(Element(msg)),
+  new_elements: List(Element(msg)),
+  key: String,
+) {
+  // This local `zip` function takes two lists of potentially different
+  // sizes and zips them together, padding the shorter list with `None`.
+  let elements = zip(old_elements, new_elements)
+  use diff, #(old, new), pos <- list.index_fold(elements, diff)
+  let key = key <> int.to_string(pos)
+
+  do_elements(diff, old, new, key)
 }
 
 pub fn attributes(
@@ -360,12 +378,22 @@ fn fold_event_handlers(
             Error(_) -> handlers
           }
         })
-      use handlers, child, index <- list.index_fold(children, handlers)
-      let key = key <> int.to_string(index)
-
-      fold_event_handlers(handlers, child, key)
+      fold_element_list_event_handlers(handlers, children, key)
     }
+    Fragment(_, elements) ->
+      fold_element_list_event_handlers(handlers, elements, key)
   }
+}
+
+fn fold_element_list_event_handlers(
+  handlers: Dict(String, Decoder(msg)),
+  elements: List(Element(msg)),
+  key: String,
+) {
+  use handlers, element, index <- list.index_fold(elements, handlers)
+  let key = key <> int.to_string(index)
+
+  fold_event_handlers(handlers, element, key)
 }
 
 pub fn is_empty_element_diff(diff: ElementDiff(msg)) -> Bool {


### PR DESCRIPTION
### Add fragment support to client

#### Summary

This commit only considered the client runtime as a jumping off point. I'm hoping to get feedback on general direction since I want to make sure it fits stylistically and within the vision for the package. 

#### Changes

- Add `Fragment` to the `Element` type
  - This could potentially be modeled as an `Element` instead of its own type perhaps?
  - I used an opaque identifier to guarantee that a fragment can be handled easily later, but it does create some duplication 
    - Maybe remove and just check to see if it has elements instead?
- Add logic to:
  - Generate json
  - Generate string
  - Generate diff
- Recognize `Fragment` within `client-runtime` 
  - If the `Fragment` is the root, it creates a root div, but is that actually the best behavior?
    - Tested this in `React` which I though did not allow top-level fragments, but it just places children within the root element, which is kind of what creating a root div does

#### TODO

- Integrate feedback!
- Needs more testing
  - Additional `client-runtime` cases
  - `server-runtime`, `components` completely

<details>
  <summary>Testing App</summary>
 
  ```
import gleam/int
import lustre
import lustre/attribute
import lustre/element.{type Element}
import lustre/element/html
import lustre/event
import lustre/ui

// MAIN ------------------------------------------------------------------------

pub fn main() {
  let app = lustre.simple(init, update, view)
  let assert Ok(_) = lustre.start(app, "#app", 0)
}

// MODEL -----------------------------------------------------------------------

type Model =
  Int

fn init(initial_count: Int) -> Model {
  case initial_count < 0 {
    True -> 0
    False -> initial_count
  }
}

// UPDATE ----------------------------------------------------------------------

pub opaque type Msg {
  Incr
  Decr
}

fn update(model: Model, msg: Msg) -> Model {
  case msg {
    Incr -> model + 1
    Decr -> model - 1
  }
}

// VIEW ------------------------------------------------------------------------

fn count_fragment(model: Model) -> Element(Msg) {
  let count = int.to_string(model)
  let count_1 = int.to_string(model + 1)
  let count_2 = int.to_string(model + 2)

  element.fragment([
    html.p([attribute.style([#("text-align", "center")])], [element.text(count)]),
    html.p([attribute.style([#("text-align", "center")])], [
      element.text(count_1),
    ]),
    html.p([attribute.style([#("text-align", "center")])], [
      element.text(count_2),
    ]),
  ])
}

fn view(model: Model) -> Element(Msg) {
  let styles = [#("width", "100vw"), #("height", "100vh"), #("padding", "1rem")]
  let count = int.to_string(model)

  element.fragment([
    ui.centre(
      [attribute.style(styles)],
      ui.stack([], [
        ui.button([event.on_click(Incr)], [element.text("+")]),
        count_fragment(model),
        element.fragment([
          element.fragment([html.p([], [element.text("immediate fragment")])]),
          html.p([attribute.style([#("text-align", "center")])], [
            element.text("nest fragment next"),
          ]),
          element.fragment([
            html.p([], [element.text("nest count")]),
            html.p([], [element.text(count)]),
            html.p([attribute.style([#("text-align", "center")])], [
              element.text("nest nest fragment"),
            ]),
            element.fragment([
              html.p([], [element.text("nest nest count")]),
              html.p([], [element.text(count)]),
            ]),
          ]),
        ]),
        ui.button([event.on_click(Decr)], [element.text("-")]),
        html.p([attribute.style([#("text-align", "center")])], [
          element.text("sibling fragment"),
        ]),
        element.fragment([
          html.p([], [element.text("sibling fragment")]),
          html.p([], [element.text(count)]),
        ]),
        html.p([], [element.text("Empty fragment next")]),
        element.fragment([]),
      ]),
    ),
  ])
}
  ```
</details>

<details>
  <summary>Testing App render screenshot</summary>

![testing-app-render-screenshot](https://github.com/lustre-labs/lustre/assets/12852633/f385e81b-1dbb-498f-bfe5-b70c3710fa4f)
</details>
