### PR TITLE
add escape function over custom attribute values

### DIFF
--- a/birdie_snapshots/can_safely_escape_dangerous_symbols_in_attributes.accepted
+++ b/birdie_snapshots/can_safely_escape_dangerous_symbols_in_attributes.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.1.2
+title: Can safely escape dangerous symbols in attributes
+---
+<div example="{&quot;mykey&quot;: &quot;myvalue&quot;}"></div>

--- a/birdie_snapshots/can_safely_escape_dangerous_symbols_in_attributes.accepted
+++ b/birdie_snapshots/can_safely_escape_dangerous_symbols_in_attributes.accepted
@@ -2,4 +2,4 @@
 version: 1.1.2
 title: Can safely escape dangerous symbols in attributes
 ---
-<div example="{&quot;mykey&quot;: &quot;myvalue&quot;}"></div>
+<div example="{&quot;mykey&quot;: &quot;myvalue&quot;}" class="&#39;badquotes&#39;" style="background:&quot;&gt;&lt;script&gt;alert`1`&lt;/script&gt;;"></div>

--- a/src/lustre/internals/vdom.gleam
+++ b/src/lustre/internals/vdom.gleam
@@ -293,7 +293,10 @@ fn attributes_to_string_builder(
         inner_html,
       )
       Ok(#(key, val)) -> #(
-        string_builder.append(html, " " <> key <> "=\"" <> val <> "\""),
+        string_builder.append(
+          html,
+          " " <> key <> "=\"" <> escape("", val) <> "\"",
+        ),
         class,
         style,
         inner_html,

--- a/src/lustre/internals/vdom.gleam
+++ b/src/lustre/internals/vdom.gleam
@@ -282,10 +282,30 @@ fn attributes_to_string_builder(
         style,
         inner_html <> val,
       )
-      Ok(#("class", val)) if class == "" -> #(html, val, style, inner_html)
-      Ok(#("class", val)) -> #(html, class <> " " <> val, style, inner_html)
-      Ok(#("style", val)) if style == "" -> #(html, class, val, inner_html)
-      Ok(#("style", val)) -> #(html, class, style <> " " <> val, inner_html)
+      Ok(#("class", val)) if class == "" -> #(
+        html,
+        escape("", val),
+        style,
+        inner_html,
+      )
+      Ok(#("class", val)) -> #(
+        html,
+        class <> " " <> escape("", val),
+        style,
+        inner_html,
+      )
+      Ok(#("style", val)) if style == "" -> #(
+        html,
+        class,
+        escape("", val),
+        inner_html,
+      )
+      Ok(#("style", val)) -> #(
+        html,
+        class,
+        style <> " " <> escape("", val),
+        inner_html,
+      )
       Ok(#(key, "")) -> #(
         string_builder.append(html, " " <> key),
         class,

--- a/test/apps/static.gleam
+++ b/test/apps/static.gleam
@@ -1,8 +1,8 @@
 // IMPORTS ---------------------------------------------------------------------
 
-import lustre/attribute.{disabled, src}
+import lustre/attribute.{attribute, disabled, src}
 import lustre/element.{text}
-import lustre/element/html.{body, h1, head, html, img, input, title}
+import lustre/element/html.{body, div, h1, head, html, img, input, title}
 
 // VIEW ------------------------------------------------------------------------
 
@@ -15,4 +15,8 @@ pub fn view() {
       img([src("https://source.unsplash.com/random")]),
     ]),
   ])
+}
+
+pub fn escaped_attribute() {
+  div([attribute("example", "{\"mykey\": \"myvalue\"}")], [])
 }

--- a/test/apps/static.gleam
+++ b/test/apps/static.gleam
@@ -1,6 +1,6 @@
 // IMPORTS ---------------------------------------------------------------------
 
-import lustre/attribute.{attribute, disabled, src}
+import lustre/attribute.{attribute, class, disabled, src, style}
 import lustre/element.{text}
 import lustre/element/html.{body, div, h1, head, html, img, input, title}
 
@@ -18,5 +18,12 @@ pub fn view() {
 }
 
 pub fn escaped_attribute() {
-  div([attribute("example", "{\"mykey\": \"myvalue\"}")], [])
+  div(
+    [
+      class("'badquotes'"),
+      style([#("background", "\"><script>alert`1`</script>")]),
+      attribute("example", "{\"mykey\": \"myvalue\"}"),
+    ],
+    [],
+  )
 }

--- a/test/lustre_test.gleam
+++ b/test/lustre_test.gleam
@@ -149,3 +149,9 @@ pub fn fragment_counter_diff_test() {
   birdie.snap(json.to_string(patch.element_diff_to_json(diff)), title)
   process.send(runtime, Shutdown)
 }
+
+pub fn escaped_attribute_test() {
+  let title = "Can safely escape dangerous symbols in attributes"
+  let el = static.escaped_attribute()
+  birdie.snap(element.to_string(el), title)
+}


### PR DESCRIPTION
this is to fix situations where attributes have quotes in their value such as:

```
div([attribute("example", "{\"mykey\": \"myvalue\"}")], [])
```

where the result when rendered in the browser is:

```
<div example="{" mykey":="" "myvalue"}"=""></div>
```

which now becomes:
```
<div example="{&quot;mykey&quot;: &quot;myvalue&quot;}"></div>
```

or as seen from the developer console:
![image](https://github.com/lustre-labs/lustre/assets/29340584/abdc679d-efbb-4728-9aa5-fa2e54abef49)

---

let me know if you want me to split the new test into a different app file or anything like that.

also, I only changed it for custom key/value pair, not when pattern matching on "class" and "style", i expect we'll want it here as well and extent the test coverage as well? just wanted to do a first pass implementation to verify i'm changing all the right bits before changing too much ha. let me know.
