### PR TITLE
Fix crash in is_browser when misused

### DIFF
--- a/src/client-runtime.ffi.mjs
+++ b/src/client-runtime.ffi.mjs
@@ -167,7 +167,7 @@ export const start = (app, selector, flags) =>
 
 // UTILS -----------------------------------------------------------------------
 
-export const is_browser = () => window && window.document;
+export const is_browser = () => globalThis.window && window.document;
 export const is_registered = (name) =>
   is_browser() && !!window.customElements.get(name);
 export const prevent_default = (event) => event.preventDefault();


### PR DESCRIPTION
If not in a browser then `window` may not be defined, resulting in a crash

I ran a command wrong and this happened:

```
$ gleam run -- -m lustre/dev --help
   Compiled in 0.04s
    Running app.main
file:///Users/louis/src/gleam/html_lustre_converter/app/build/dev/javascript/lustre/client-runtime.ffi.mjs:170
export const is_browser = () => window && window.document;
                                       ^

ReferenceError: window is not defined
    at is_browser (file:///Users/louis/src/gleam/html_lustre_converter/app/build/dev/javascript/lustre/client-runtime.ffi.mjs:170:40)
    at Module.start (file:///Users/louis/src/gleam/html_lustre_converter/app/build/dev/javascript/lustre/lustre.mjs:101:6)
    at main (file:///Users/louis/src/gleam/html_lustre_converter/app/build/dev/javascript/app/app.mjs:7:19)
    at file:///Users/louis/src/gleam/html_lustre_converter/app/build/dev/javascript/app/gleam.main.mjs:2:1
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:336:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12)
```