### PR TITLE
Implement `Lazy` elements in VDOM

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -59,10 +59,7 @@ pub fn none() -> Attribute(msg) {
 /// you map the messages produced from one type to another.
 ///
 pub fn map(attr: Attribute(a), f: fn(a) -> b) -> Attribute(b) {
-  case attr {
-    Attribute(name, value, as_property) -> Attribute(name, value, as_property)
-    Event(on, handler) -> Event(on, fn(e) { result.map(handler(e), f) })
-  }
+  vdom.map_attribute(attr, f)
 }
 
 // COMMON ATTRIBUTES -----------------------------------------------------------

--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -312,71 +312,7 @@ fn escape(escaped: String, content: String) -> String {
 /// Think of it like `list.map` or `result.map` but for HTML events!
 ///
 pub fn map(element: Element(a), f: fn(a) -> b) -> Element(b) {
-  case element {
-    Text(content) -> Text(content)
-    Map(subtree) -> Map(fn() { map(subtree(), f) })
-    Element(key, namespace, tag, attrs, children, self_closing, void) ->
-      Map(fn() {
-        Element(
-          key: key,
-          namespace: namespace,
-          tag: tag,
-          attrs: list.map(attrs, attribute.map(_, f)),
-          children: list.map(children, map(_, f)),
-          self_closing: self_closing,
-          void: void,
-        )
-      })
-    Fragment(elements, key) -> {
-      Map(fn() { Fragment(list.map(elements, map(_, f)), key) })
-    }
-    Lazy(params, view) ->
-      Map(fn() {
-        case params {
-          [_] ->
-            Lazy(
-              params,
-              dynamic.from(fn(a) { map(dynamic.unsafe_coerce(view)(a), f) }),
-            )
-          [_, _] ->
-            Lazy(
-              params,
-              dynamic.from(fn(a, b) {
-                map(dynamic.unsafe_coerce(view)(a, b), f)
-              }),
-            )
-          [_, _, _] ->
-            Lazy(
-              params,
-              dynamic.from(fn(a, b, c) {
-                map(dynamic.unsafe_coerce(view)(a, b, c), f)
-              }),
-            )
-          [_, _, _, _] ->
-            Lazy(
-              params,
-              dynamic.from(fn(a, b, c, d) {
-                map(dynamic.unsafe_coerce(view)(a, b, c, d), f)
-              }),
-            )
-          [_, _, _, _, _] ->
-            Lazy(
-              params,
-              dynamic.from(fn(a, b, c, d, e) {
-                map(dynamic.unsafe_coerce(view)(a, b, c, d, e), f)
-              }),
-            )
-          [_, _, _, _, _, _] ->
-            Lazy(
-              params,
-              dynamic.from(fn(a, b, c, d, e, ff) {
-                map(dynamic.unsafe_coerce(view)(a, b, c, d, e, ff), f)
-              }),
-            )
-          _ -> panic as "Unhandled lazyX"
-        }
-      })
-  }
+  vdom.map_element(element, f)
 }
 
 // CONVERSIONS -----------------------------------------------------------------
@@ -440,17 +376,18 @@ pub fn to_document_string_builder(el: Element(msg)) -> StringBuilder {
 }
 
 pub fn lazy1(param: a, view: fn(a) -> Element(msg)) {
-  Lazy([dynamic.from(param)], dynamic.from(view))
+  Lazy([dynamic.from(param)], dynamic.from(view), [])
 }
 
 pub fn lazy2(param1: a, param2: b, view: fn(a, b) -> Element(msg)) {
-  Lazy([dynamic.from(param1), dynamic.from(param2)], dynamic.from(view))
+  Lazy([dynamic.from(param1), dynamic.from(param2)], dynamic.from(view), [])
 }
 
 pub fn lazy3(param1: a, param2: b, param3: c, view: fn(a, b, c) -> Element(msg)) {
   Lazy(
     [dynamic.from(param1), dynamic.from(param2), dynamic.from(param3)],
     dynamic.from(view),
+    [],
   )
 }
 
@@ -469,6 +406,7 @@ pub fn lazy4(
       dynamic.from(param4),
     ],
     dynamic.from(view),
+    [],
   )
 }
 
@@ -489,6 +427,7 @@ pub fn lazy5(
       dynamic.from(param5),
     ],
     dynamic.from(view),
+    [],
   )
 }
 
@@ -511,5 +450,6 @@ pub fn lazy6(
       dynamic.from(param6),
     ],
     dynamic.from(view),
+    [],
   )
 }

--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -330,7 +330,52 @@ pub fn map(element: Element(a), f: fn(a) -> b) -> Element(b) {
     Fragment(elements, key) -> {
       Map(fn() { Fragment(list.map(elements, map(_, f)), key) })
     }
-    Lazy(arg, view) -> Map(fn() { Lazy(arg, fn(_) { map(view(arg), f) }) })
+    Lazy(params, view) ->
+      Map(fn() {
+        case params {
+          [_] ->
+            Lazy(
+              params,
+              dynamic.from(fn(a) { map(dynamic.unsafe_coerce(view)(a), f) }),
+            )
+          [_, _] ->
+            Lazy(
+              params,
+              dynamic.from(fn(a, b) {
+                map(dynamic.unsafe_coerce(view)(a, b), f)
+              }),
+            )
+          [_, _, _] ->
+            Lazy(
+              params,
+              dynamic.from(fn(a, b, c) {
+                map(dynamic.unsafe_coerce(view)(a, b, c), f)
+              }),
+            )
+          [_, _, _, _] ->
+            Lazy(
+              params,
+              dynamic.from(fn(a, b, c, d) {
+                map(dynamic.unsafe_coerce(view)(a, b, c, d), f)
+              }),
+            )
+          [_, _, _, _, _] ->
+            Lazy(
+              params,
+              dynamic.from(fn(a, b, c, d, e) {
+                map(dynamic.unsafe_coerce(view)(a, b, c, d, e), f)
+              }),
+            )
+          [_, _, _, _, _, _] ->
+            Lazy(
+              params,
+              dynamic.from(fn(a, b, c, d, e, ff) {
+                map(dynamic.unsafe_coerce(view)(a, b, c, d, e, ff), f)
+              }),
+            )
+          _ -> panic as "Unhandled lazyX"
+        }
+      })
   }
 }
 
@@ -394,6 +439,77 @@ pub fn to_document_string_builder(el: Element(msg)) -> StringBuilder {
   |> string_builder.prepend("<!doctype html>\n")
 }
 
-pub fn lazy(arg: a, view: fn(a) -> Element(msg)) {
-  Lazy(dynamic.from(arg), dynamic.unsafe_coerce(dynamic.from(view)))
+pub fn lazy1(param: a, view: fn(a) -> Element(msg)) {
+  Lazy([dynamic.from(param)], dynamic.from(view))
+}
+
+pub fn lazy2(param1: a, param2: b, view: fn(a, b) -> Element(msg)) {
+  Lazy([dynamic.from(param1), dynamic.from(param2)], dynamic.from(view))
+}
+
+pub fn lazy3(param1: a, param2: b, param3: c, view: fn(a, b, c) -> Element(msg)) {
+  Lazy(
+    [dynamic.from(param1), dynamic.from(param2), dynamic.from(param3)],
+    dynamic.from(view),
+  )
+}
+
+pub fn lazy4(
+  param1: a,
+  param2: b,
+  param3: c,
+  param4: d,
+  view: fn(a, b, c, d) -> Element(msg),
+) {
+  Lazy(
+    [
+      dynamic.from(param1),
+      dynamic.from(param2),
+      dynamic.from(param3),
+      dynamic.from(param4),
+    ],
+    dynamic.from(view),
+  )
+}
+
+pub fn lazy5(
+  param1: a,
+  param2: b,
+  param3: c,
+  param4: d,
+  param5: e,
+  view: fn(a, b, c, d, e) -> Element(msg),
+) {
+  Lazy(
+    [
+      dynamic.from(param1),
+      dynamic.from(param2),
+      dynamic.from(param3),
+      dynamic.from(param4),
+      dynamic.from(param5),
+    ],
+    dynamic.from(view),
+  )
+}
+
+pub fn lazy6(
+  param1: a,
+  param2: b,
+  param3: c,
+  param4: d,
+  param5: e,
+  param6: f,
+  view: fn(a, b, c, d, e, f) -> Element(msg),
+) {
+  Lazy(
+    [
+      dynamic.from(param1),
+      dynamic.from(param2),
+      dynamic.from(param3),
+      dynamic.from(param4),
+      dynamic.from(param5),
+      dynamic.from(param6),
+    ],
+    dynamic.from(view),
+  )
 }

--- a/src/lustre/internals/patch.gleam
+++ b/src/lustre/internals/patch.gleam
@@ -143,9 +143,11 @@ fn do_elements(
             created: dict.insert(diff.created, key, new),
             handlers: fold_event_handlers(diff.handlers, new, key),
           )
-        Lazy(old_arg, old_view), Lazy(new_arg, new_view) -> {
+        Lazy(old_arg, old_view, old_mappers),
+          Lazy(new_arg, new_view, new_mappers)
+        -> {
           case old_arg == new_arg {
-            True if old_view == new_view -> diff
+            True if old_view == new_view && old_mappers == new_mappers -> diff
             _ ->
               do_elements(
                 diff,
@@ -155,7 +157,7 @@ fn do_elements(
               )
           }
         }
-        _, Lazy(_, _) -> {
+        _, Lazy(_, _, _) -> {
           let new = vdom.apply_lazy(new)
           ElementDiff(
             ..diff,
@@ -163,7 +165,7 @@ fn do_elements(
             handlers: fold_event_handlers(diff.handlers, new, key),
           )
         }
-        Lazy(_, _), _ -> {
+        Lazy(_, _, _), _ -> {
           ElementDiff(
             ..diff,
             created: dict.insert(diff.created, key, new),
@@ -446,7 +448,8 @@ fn fold_event_handlers(
     }
     Fragment(elements, _) ->
       fold_element_list_event_handlers(handlers, elements, key)
-    Lazy(_, _) -> fold_event_handlers(handlers, vdom.apply_lazy(element), key)
+    Lazy(_, _, _) ->
+      fold_event_handlers(handlers, vdom.apply_lazy(element), key)
   }
 }
 

--- a/src/lustre/internals/patch.gleam
+++ b/src/lustre/internals/patch.gleam
@@ -149,14 +149,14 @@ fn do_elements(
             _ ->
               do_elements(
                 diff,
-                Some(old_view(old_arg)),
-                Some(new_view(new_arg)),
+                Some(vdom.apply_lazy(old)),
+                Some(vdom.apply_lazy(new)),
                 key,
               )
           }
         }
-        _, Lazy(new_arg, new_view) -> {
-          let new = new_view(new_arg)
+        _, Lazy(_, _) -> {
+          let new = vdom.apply_lazy(new)
           ElementDiff(
             ..diff,
             created: dict.insert(diff.created, key, new),
@@ -446,7 +446,7 @@ fn fold_event_handlers(
     }
     Fragment(elements, _) ->
       fold_element_list_event_handlers(handlers, elements, key)
-    Lazy(arg, view) -> fold_event_handlers(handlers, view(arg), key)
+    Lazy(_, _) -> fold_event_handlers(handlers, vdom.apply_lazy(element), key)
   }
 }
 

--- a/src/lustre/internals/vdom.gleam
+++ b/src/lustre/internals/vdom.gleam
@@ -27,6 +27,7 @@ pub type Element(msg) {
   // This means we pay the cost of mapping multiple times only *once* during rendering.
   Map(subtree: fn() -> Element(msg))
   Fragment(elements: List(Element(msg)), key: String)
+  Lazy(arg: Dynamic, lazy_view: fn(Dynamic) -> Element(msg))
 }
 
 pub type Attribute(msg) {
@@ -61,6 +62,7 @@ fn do_handlers(
       do_element_list_handlers(children, handlers, key)
     }
     Fragment(elements, _) -> do_element_list_handlers(elements, handlers, key)
+    Lazy(arg, view) -> do_handlers(view(arg), handlers, key)
   }
 }
 
@@ -102,6 +104,7 @@ fn do_element_to_json(element: Element(msg), key: String) -> Json {
     }
     Fragment(elements, _) ->
       json.object([#("elements", do_element_list_to_json(elements, key))])
+    Lazy(arg, view) -> do_element_to_json(view(arg), key)
   }
 }
 
@@ -267,6 +270,7 @@ fn do_element_to_string_builder(
     }
     Fragment(elements, _) ->
       children_to_string_builder(string_builder.new(), elements, raw_text)
+    Lazy(arg, view) -> do_element_to_string_builder(view(arg), raw_text)
   }
 }
 

--- a/src/vdom.ffi.mjs
+++ b/src/vdom.ffi.mjs
@@ -95,7 +95,8 @@ export function morph(prev, next, dispatch, isComponent = false) {
             while (
               prev.isLazy &&
               prev.lazyArg === prev.nextSibling?.lazyArg &&
-              prev.lazyView === prev.nextSibling?.lazyView
+              prev.lazyView === prev.nextSibling?.lazyView &&
+              prev.lazyTimestamp === prev.nextSibling?.lazyTimestamp
             ) {
               prev = prev.nextSibling;
             }
@@ -152,6 +153,7 @@ function setLazy(element, lazy) {
     element.isLazy = true;
     element.lazyArg = lazy.arg;
     element.lazyView = lazy.view;
+    element.lazyTimestamp = lazy.timestamp;
   }
 }
 
@@ -424,7 +426,8 @@ function createElementNode({ prev, next, dispatch, stack }) {
         while (
           prevChild.isLazy &&
           prevChild.lazyArg === prevChild.nextSibling?.lazyArg &&
-          prevChild.lazyView === prevChild.nextSibling?.lazyView
+          prevChild.lazyView === prevChild.nextSibling?.lazyView &&
+          prevChild.lazyTimestamp === prevChild.nextSibling?.lazyTimestamp
         ) {
           prevChild = prevChild.nextSibling;
         }
@@ -644,7 +647,8 @@ function iterateElement(element, previousElement, processElement, lazy) {
       previousElement?.lazyView !== element.lazy_view
     ) {
       const next = element.lazy_view(element.arg);
-      const lazy = { arg: element.arg, view: element.lazy_view };
+      const timestamp = performance.now();
+      const lazy = { arg: element.arg, view: element.lazy_view, timestamp };
       iterateElement(next, previousElement, processElement, lazy);
     } else {
       processElement({ element: null });


### PR DESCRIPTION
This is a first draft for the lazy handling in the VDOM. Implementation should be fully working in the JS SPA, but should be debugged for server components.

# How it works?

Lazy nodes are implemented by leveraging on the DOM. Every time a lazy node has to be created, a `lazy` property is set on the node, containing the params used to generate the VDOM subtree, as well as its function and the timestamp at which the subtree has been generated (more on that later). At every repaint, the lazy nodes will be compared to the real DOM node, containing the `lazy` property. A check is done on the parameters, by comparing them one by one. If it ends up by not needing to repaint the lazy node, then the real DOM node will be kept, and skipped in the render. If it's needed to repaint, then the lazy function will be executed, and the node replaced.

### Why using a Timestamp?

The timestamp is there to distinguish an edge case in the VDOM. Let's illustrate it:

```gleam
pub fn view_item(content) {
  element.fragment([
    html.div([], [html.text(content)]),
    html.div([], [html.text(content)]),
  ])
}

pub fn view() {
  html.div([], [
    element.lazy1("Bonjour", view_item),
    element.lazy1("Bonjour", view_item),
    element.lazy1("Monde!", view_item),
  ])
}
```

In such cases, and because there's multiple fragment, the generated HTML should be:

```html
<div>
  <div>Bonjour</div>
  <div>Bonjour</div>
  <div>Bonjour</div>
  <div>Bonjour</div>
  <div>Monde</div>
  <div>Monde</div>
</div>
```

When repaint the first `lazy1` here, there's no way to determine how much from the previous render should be skipped. We could compare the params, but here, the 4 first nodes will have the same functions and the same params. After a rerender, we'll end up with a DOM like this:

```html
<div>
  <div>Bonjour</div>
  <div>Bonjour</div>
  <div>Bonjour</div>
  <div>Bonjour</div>
  <div>Bonjour</div>
  <div>Bonjour</div>
  <div>Monde</div>
  <div>Monde</div>
</div>
```

Because the 4 first nodes will be considered as the first lazy (and skipped), and the second lazy will be compared to nothing, and thus new nodes will be added. To catch this bug, a timestamp is added to every nodes in a lazy rendering. This means we are now able to distinguish the nodes added in the render, and so skip the exact number of nodes from the previous fragment.
The HTML is similar to:

```html
<div>
  <div ts="1">Bonjour</div>
  <div ts="1">Bonjour</div>
  <div ts="2">Bonjour</div>
  <div ts="2">Bonjour</div>
  <div ts="3">Monde</div>
  <div ts="3">Monde</div>
</div>
```

So we can only compare the timestamp, and we can completely skip the params comparison!

By the way, it does not have to be a timestamp, but only a guaranteed unique integer. Time is guaranteed to be monotonically growing over time, thanks to `performance.now`. Random ints could be simple generated on BEAM, by using `erlang:unique_integer`.