### PR TITLE
🐛 Update JSON structure of a Fragment to match JS structure

### DIFF
--- a/src/lustre/internals/vdom.gleam
+++ b/src/lustre/internals/vdom.gleam
@@ -100,7 +100,8 @@ fn do_element_to_json(element: Element(msg), key: String) -> Json {
         #("void", json.bool(void)),
       ])
     }
-    Fragment(elements, _) -> do_element_list_to_json(elements, key)
+    Fragment(elements, _) ->
+      json.object([#("elements", do_element_list_to_json(elements, key))])
   }
 }
 


### PR DESCRIPTION
The JSON representation of a fragment didn't  match the JS representation, and was missed when the vdom was rendering the elements. Updated the representation to match what is expected by the vdom impl (and also what is used in a full client side application)