### PR TITLE
:bug: Fix when a Fragment is put in VDOM stack, because of Map

### DIFF
--- a/src/vdom.ffi.mjs
+++ b/src/vdom.ffi.mjs
@@ -553,16 +553,19 @@ function diffKeyedChild(
   return prevChild;
 }
 
-/*
- Iterate element, helper to apply the same functions to a standard "Element" or "Fragment" transparently
- 1. If single element, call callback for that element
- 2. If fragment, call callback for every child element. Fragment constructor guarantees no Fragment children
+/**
+ Iterate element, helper to apply the same functions to a standard `Element`, `Fragment` or `Map` transparently
+ 1. If single `Element`, call callback for that element
+ 2. If `Fragment`, call callback for every child element. Fragment constructor guarantees no Fragment children
+ 3. If `Map`, compute the subtree and call callback for every child element. This case happens when using an `element.map` on a `Fragment`.
 */
 function iterateElement(element, processElement) {
   if (element.elements !== undefined) {
     for (const currElement of element.elements) {
       processElement(currElement);
     }
+  } else if (element.subtree !== undefined) {
+    iterateElement(element.subtree(), processElement);
   } else {
     processElement(element);
   }


### PR DESCRIPTION
# What ?

In lustre 4.3.0, a bug happens when combining fragments and `element.map`. Below, a simple, small reproducible example.

<details><summary>Reproducible Example</summary>
<p>

```gleam
import gleam/int
import lustre
import lustre/element.{text}
import lustre/element/html.{button, div, p}
import lustre/event.{on_click}

pub fn main() {
  let app = lustre.simple(init, update, view)
  let assert Ok(_) = lustre.start(app, "#app", Nil)

  Nil
}

fn init(_flags) {
  0
}

type Msg {
  Counter(Counter)
}

type Counter {
  Incr
  Decr
}

fn update(model, msg) {
  case msg {
    Counter(Incr) -> model + 1
    Counter(Decr) -> model - 1
  }
}

fn view(model) {
  let count = int.to_string(model)

  element.map(
    div([], [
      button([on_click(Incr)], [text(" + ")]),
      p([], [text(count)]),
      bloup(),
      p([], [text(count)]),
      bloup(),
      p([], [text(count)]),
      bloup(),
      button([on_click(Decr)], [text(" - ")]),
    ]),
    Counter,
  )
}

fn bloup() {
  element.fragment([html.div([], [element.text("meh")])])
}
```

</p>
</details> 

The bug is rather vicious and hard to get. *At first paint*, the DOM is messed up, and will appear like this: 

<details><summary>DOM state</summary>
<img width="115" alt="Capture d’écran 2024-06-29 à 17 10 31" src="https://github.com/lustre-labs/lustre/assets/7314118/f9af5034-12fb-4017-888f-cb72187ff668">
</details>

After a first repaint, the DOM will take its correct place, because everything is now working smoothly.

# Why ?

At first paint, the DOM is empty. It means the `prev` node in the VDOM stack will always be null. In such cases, the behaviour of the DOM is simply to put the next node as the last child of the parent. At first paint, when processing a subtree containing a fragment, [the VDOM will fall in that case](https://github.com/lustre-labs/lustre/blob/f0d8e80229002bfa190b5b30b6a45d0ac66b27be/src/vdom.ffi.mjs#L74). That case should never be reached, unless the VDOM is processing the first node of the document. [Due to that `Map` handling](https://github.com/lustre-labs/lustre/blob/f0d8e80229002bfa190b5b30b6a45d0ac66b27be/src/vdom.ffi.mjs#L30), the `Fragment` case becomes possible. The VDOM will behaves incorrectly, because it will consider the nested `Fragment` as a top-level `Fragment`, which is false.

# How to fix ?

The fix is simple and straightforward: it consists to consider every `Map` node which is not a top-level `Map` as an element, like a `Fragment`. `iterateElement` is already in charge of this. The fix computes the subtree when encountering a `Map`, and iterate on every children. The fix make sure no `Map` is now pushed in the VDOM stack, unless that `Map` is the first encountered node in the view.

---

### Nice to have

The `iterateElement` comment is now a proper JSDoc comment, meaning IDE and LSP will now display the comment when hovering on it, simplifying reading for reviewers and maintainers.