### PR TITLE
fix: fix type typo

### DIFF
--- a/pages/guide/08-components.md
+++ b/pages/guide/08-components.md
@@ -61,7 +61,7 @@ pub type MyButtonProps(msg) {
     label: String,
     msg: msg,
     colour: Colour,
-    variant: Variant,
+    variant: MyButtonVariant,
     icon: Option(Icon)
   )
 }


### PR DESCRIPTION
First ever pull request! Let's see how this goes :-)

I was reading the Lustre docs and came across this usage of `variant: Variant` while the defined type seem to be called `MyButtonVariant`