### PR TITLE
Add example for effect.from

### DIFF
--- a/src/lustre/effect.gleam
+++ b/src/lustre/effect.gleam
@@ -65,6 +65,16 @@ pub opaque type Effect(msg) {
 /// called with a `dispatch` function you can use to send messages back to your
 /// application's `update` function.
 ///
+/// Example using the `window` module from the `plinth` library to dispatch a
+/// message on the browser window object's `"visibilitychange"` event.
+///
+/// ```gleam
+/// from(fn(dispatch) {
+///   window.add_event_listener("visibilitychange", fn(_event) {
+///     dispatch(FetchState)
+///   })
+/// })
+/// ```
 pub fn from(effect: fn(fn(msg) -> Nil) -> Nil) -> Effect(msg) {
   // Effects constructed with `effect.from` only get told about the `dispatch`
   // function. If users want to emit events from a component they should use

--- a/src/lustre/effect.gleam
+++ b/src/lustre/effect.gleam
@@ -69,11 +69,27 @@ pub opaque type Effect(msg) {
 /// message on the browser window object's `"visibilitychange"` event.
 ///
 /// ```gleam
-/// from(fn(dispatch) {
-///   window.add_event_listener("visibilitychange", fn(_event) {
-///     dispatch(FetchState)
-///   })
-/// })
+/// import lustre/effect.{type Effect}
+/// import plinth/browser/window
+///
+/// type Model {
+///   Model(Int)
+/// }
+///
+/// type Msg {
+///   FetchState
+/// }
+///
+/// fn init(_flags) -> #(Model, Effect(Msg)) {
+///   #(
+///     Model(0),
+///     effect.from(fn(dispatch) {
+///       window.add_event_listener("visibilitychange", fn(_event) {
+///         dispatch(FetchState)
+///       })
+///     }),
+///   )
+/// }
 /// ```
 pub fn from(effect: fn(fn(msg) -> Nil) -> Nil) -> Effect(msg) {
   // Effects constructed with `effect.from` only get told about the `dispatch`


### PR DESCRIPTION
I found it hard to figure out exactly how it should be used without clicking through to the code where the variable names helped me a little.

I hope that this could be useful to include. I'm not sure how we feel about having other libraries in code examples. I guess I like the idea of its being more real world but I also realise that plinth library might change and render this out of date which isn't so great. 

I'm not sure if any core libraries expose a repeater timer concept as that could also be a real world example. To refresh some data every minute or something.