### PR TITLE
Fix fragment that could be pushed in tree, which is invalid

### DIFF
--- a/src/vdom.ffi.mjs
+++ b/src/vdom.ffi.mjs
@@ -562,7 +562,7 @@ function diffKeyedChild(
 function iterateElement(element, processElement) {
   if (element.elements !== undefined) {
     for (const currElement of element.elements) {
-      processElement(currElement);
+      iterateElement(currElement, processElement);
     }
   } else if (element.subtree !== undefined) {
     iterateElement(element.subtree(), processElement);


### PR DESCRIPTION
Small fix here, but this was breaking for a specific use case:

```
el.fragment([
  el.map(...),
])
```

Because the map pushed in the tree. Going through `iterateElement` remove any undesired `Element` in the tree (i.e. `Fragment` & `Map`). 