### PR TITLE
:memo: add deployment guide for SPAs

### DIFF
--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: gleam deps download
       - name: Build app
-        run: gleam run -m lustre/dev build app
+        run: gleam run -m lustre/dev build app --minify
       - name: Copy output to dist
         run: mkdir dist && cp index.html dist/index.html && cp -r priv dist/priv
       - name: Deploy with Wrangler

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -58,11 +58,12 @@ In other words, this project setup closely resembles the [Hello World example](h
 Create a new file in your repository at `.github/workflows/deploy.yml` and use the following template as a starting point:
 
 ```yaml
+name: Deploy to Cloudflare Pages
+
 on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   deploy:
@@ -72,11 +73,9 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - name: Checkout
-        id: checkout
+      - name: Checkout repo
         uses: actions/checkout@v4
       - name: Set up Gleam
-        id: setup-gleam
         uses: erlef/setup-beam@v1
         with:
           otp-version: "27.0"
@@ -87,15 +86,16 @@ jobs:
       - name: Build app
         run: gleam run -m lustre/dev build app --minify
       - name: Copy output to dist
-        run: mkdir dist && cp index.html dist/index.html && cp -r priv dist/priv
+        run: |
+          mkdir -p dist
+          cp index.html dist/index.html
+          cp -r priv dist/priv
       - name: Deploy with Wrangler
-        id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name <YOUR_PROJECT_NAME>
-        if: github.ref == 'refs/heads/main'
 ```
 
 Make sure to replace `<YOUR_PROJECT_NAME>` with the name of your Cloudflare Pages project and also to update the Gleam and OTP versions to match your project's requirements.

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -2,13 +2,119 @@
 
 If you have built a Lustre application that doesn't have a backend you need to
 deploy, you can use a number of static hosting services to get your SPA online.
-In this guide we'll look at two options, GitHub Pages and Netlify.
+In this guide we'll look at three options, Cloudflare Pages, GitHub Pages and Netlify.
 
 If you are planning on building and deploying a full stack Gleam project, you
 probably don't want to follow this guide!
 
+## Deploying with Cloudflare Pages
+
+There are multiple ways to deploy a Lustre SPA with Cloudflare Pages. For this guide we will focus on automated deployments using GitHub Actions. We will opt out of "Automatic Deployments" since it does not support Gleam and/or Lustre. Instead, we build our application with `lustre_dev_tools` use the Wrangler action to deploy our application.
+
+First, in this guide we assume that you build your Lustre application with:
+
+```
+gleam run -m lustre/dev build app
+```
+
+and that this results in a `priv/static` directory in your repository root. The built application is then loaded in a `<script>` tag in your HTML file (`index.html`), also located in your repository root directory.
+
+In other words, this setup closely resembels the [Hello World example](https://github.com/lustre-labs/lustre/tree/main/examples/01-hello-world).
+
+### Setting up Cloudflare Pages
+
+#### Create a Cloudflare Pages Project:
+
+1. Go to the Cloudflare dashboard.
+2. Navigate to the "Workers & Pages" section.
+3. Create a new project.
+4. Create a new project and connect it to your GitHub repository.
+5. During setup, select the appropriate branch (for example `main`) to deploy from.
+6. Ignore the build settings for now.
+
+#### Disable Automatic Deployments:
+
+1. After creating the project, navigate to the project settings.
+2. Under "Builds & Deployments", disable "Automatic Deployments" for production and preview branches.
+
+### Setting up GitHub Actions
+
+#### Set Environment Variables
+
+1. Go to your repository settings on GitHub.
+2. Navigate to the Secrets section.
+3. Add a new `CLOUDFLARE_ACCOUNT_ID` secret based on:
+   - Go to any Zone in your Cloudflare account.
+   - Copy the Account ID from the right sidebar and paste it as the secret value.
+4. Add a new `CLOUDFLARE_API_TOKEN` secret based on:
+   - Go to "My Profile" from the top right dropdown menu.
+   - Navigate to the "API Tokens" section.
+   - Create a new custom API token with the `Cloudflare Pages`: `Edit` permission.
+   - Copy the API token and paste it as the secret value.
+
+#### Create a GitHub Actions Workflow
+
+Create a new file in your repository at `.github/workflows/deploy.yml` and use the following template as a starting point:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+      - name: Set up Gleam
+        id: setup-gleam
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27.0"
+          gleam-version: "1.4.1"
+          rebar3-version: "3"
+      - name: Install dependencies
+        run: gleam deps download
+      - name: Build app
+        run: gleam run -m lustre/dev build app
+      - name: Copy output to dist
+        run: mkdir dist && cp index.html dist/index.html && cp -r priv dist/priv
+      - name: Deploy with Wrangler
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name <YOUR_PROJECT_NAME>
+        if: github.ref == 'refs/heads/main'
+```
+
+Make sure to replace `<YOUR_PROJECT_NAME>` with the name of your Cloudflare Pages project and also to update the Gleam and OTP versions to match your project's requirements.
+
+This workflow:
+  - Installs Gleam and its dependencies.
+  - Builds the Lustre application.
+  - Copies the built application to a `dist/` directory.
+  - Deploys the `dist/` directory to Cloudflare Pages using Wrangler.
+
+### Deploying
+
+After setting up the GitHub Actions workflow, you can now push your changes to the `main` branch to trigger a deployment to Cloudflare Pages.
+
+Your application should now be available at the Cloudflare Pages URL!
+
 ## Deploying with GitHub Pages
 
-
+🚧
 
 ## Deploying with Netlify
+
+🚧

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -9,17 +9,17 @@ probably don't want to follow this guide!
 
 ## Deploying with Cloudflare Pages
 
-There are multiple ways to deploy a Lustre SPA with Cloudflare Pages. For this guide we will focus on automated deployments using GitHub Actions. We will opt out of "Automatic Deployments" since it does not support Gleam and/or Lustre. Instead, we build our application with `lustre_dev_tools` and use the Wrangler action to deploy our application.
+There are multiple ways to deploy a Lustre SPA with Cloudflare Pages. For this guide we will focus on automated deployments using GitHub Actions. We will opt out of Cloudflare's "Automatic Deployments" since it does not support Gleam and/or Lustre. Instead, we build our application with `lustre_dev_tools` and use the Wrangler action to deploy our application.
 
-First, in this guide we assume that you build your Lustre application with:
+In this guide we also assume that you build your Lustre application with:
 
 ```
 gleam run -m lustre/dev build app
 ```
 
-and that this results in a `priv/static` directory in your repository root. The built application is then loaded in a `<script>` tag in your HTML file (`index.html`), also located in your repository root directory.
+and that this results in a `priv/static` directory in your repository root directory. The built application is then loaded in a `<script>` tag in your HTML file (`index.html`), located in your repository root directory.
 
-In other words, this setup closely resembles the [Hello World example](https://github.com/lustre-labs/lustre/tree/main/examples/01-hello-world).
+In other words, this project setup closely resembles the [Hello World example](https://github.com/lustre-labs/lustre/tree/main/examples/01-hello-world).
 
 ### Setting up Cloudflare Pages
 

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -24,6 +24,8 @@ Finally, we also assume that you have a GitHub repository set up for your Lustre
 
 There are multiple ways to deploy a Lustre SPA with GitHub Pages. For this guide we will focus on automated deployments using GitHub Actions. We will build our application with `lustre_dev_tools` and use the GitHub Actions workflow to deploy our application.
 
+> **Note**: when deploying with GitHub Pages, remember that your application will be served at `https://<username>.github.io/<repository>`. The `<repository>` part of the URL is important as you will need to update the `<script>` tag in `index.html` to point to the correct file. In the Hello World example, this would be `/<repository>/priv/static/app.mjs`. Otherwise, your application will not load and you will see a 404 error in the browser console.
+
 ### Setting up GitHub Pages
 
 1. Go to your repository settings on GitHub.

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -2,8 +2,7 @@
 
 If you have built a Lustre application that doesn't have a backend you need to deploy, you can use a number of static hosting services to get your SPA online. In this guide we'll look at two options, GitHub Pages and Cloudflare Pages, but the principles can be applied to other services as well.
 
-If you are planning on building and deploying a full stack Gleam project, you
-probably don't want to follow this guide!
+If you are planning on building and deploying a full stack Gleam project, you probably don't want to follow this guide!
 
 ## Prerequisites
 
@@ -70,7 +69,7 @@ jobs:
       - name: Copy output to dist
         run: |
           mkdir -p dist
-          cp index.github.html dist/index.html
+          cp index.html dist/index.html
           cp -r priv dist/priv
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -83,7 +82,7 @@ jobs:
         uses: actions/deploy-pages@v4
 ```
 
-Make sure to update the Gleam and OTP versions to match your project's requirements.
+> **Note**: Make sure to update the Gleam and OTP versions to match your project's requirements.
 
 This workflow:
 
@@ -178,7 +177,7 @@ jobs:
           command: pages deploy dist --project-name <YOUR_PROJECT_NAME>
 ```
 
-Make sure to replace `<YOUR_PROJECT_NAME>` with the name of your Cloudflare Pages project and also to update the Gleam and OTP versions to match your project's requirements.
+> **Note**: Make sure to replace `<YOUR_PROJECT_NAME>` with the name of your Cloudflare Pages project and also to update the Gleam and OTP versions to match your project's requirements.
 
 This workflow:
 

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -104,7 +104,7 @@ There are multiple ways to deploy a Lustre SPA with Cloudflare Pages. For this g
 
 ### Setting up Cloudflare Pages
 
-#### Create a Cloudflare Pages Project:
+#### Create a Cloudflare Pages Project
 
 1. Go to the Cloudflare dashboard.
 2. Navigate to the "Workers & Pages" section.
@@ -112,7 +112,7 @@ There are multiple ways to deploy a Lustre SPA with Cloudflare Pages. For this g
 4. During setup, select the appropriate branch (e.g. `main`) to deploy from.
 5. Ignore the build settings for now.
 
-#### Disable Automatic Deployments:
+#### Disable Automatic Deployments
 
 1. After creating the project, navigate to the project settings.
 2. Under "Builds & Deployments", disable "Automatic Deployments" for production and preview branches.

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -21,7 +21,7 @@ and that this results in a `priv/static` directory in your repository root direc
 
 In other words, this project setup closely resembles the [Hello World example](https://github.com/lustre-labs/lustre/tree/main/examples/01-hello-world).
 
-> **Note**: when using the `--minify` flag in the build command, remember to update your `<script>` tag in `index.html` to point to the minified file. In the Hello World example, this would be `/priv/static/app.min.js` instead of `/priv/static/app.js`.
+> **Note**: when using the `--minify` flag in the build command, remember to update your `<script>` tag in `index.html` to point to the minified file. In the Hello World example, this would be `/priv/static/app.min.mjs` instead of `/priv/static/app.mjs`.
 
 ### Setting up Cloudflare Pages
 

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -9,7 +9,7 @@ probably don't want to follow this guide!
 
 ## Deploying with Cloudflare Pages
 
-There are multiple ways to deploy a Lustre SPA with Cloudflare Pages. For this guide we will focus on automated deployments using GitHub Actions. We will opt out of "Automatic Deployments" since it does not support Gleam and/or Lustre. Instead, we build our application with `lustre_dev_tools` use the Wrangler action to deploy our application.
+There are multiple ways to deploy a Lustre SPA with Cloudflare Pages. For this guide we will focus on automated deployments using GitHub Actions. We will opt out of "Automatic Deployments" since it does not support Gleam and/or Lustre. Instead, we build our application with `lustre_dev_tools` and use the Wrangler action to deploy our application.
 
 First, in this guide we assume that you build your Lustre application with:
 
@@ -19,7 +19,7 @@ gleam run -m lustre/dev build app
 
 and that this results in a `priv/static` directory in your repository root. The built application is then loaded in a `<script>` tag in your HTML file (`index.html`), also located in your repository root directory.
 
-In other words, this setup closely resembels the [Hello World example](https://github.com/lustre-labs/lustre/tree/main/examples/01-hello-world).
+In other words, this setup closely resembles the [Hello World example](https://github.com/lustre-labs/lustre/tree/main/examples/01-hello-world).
 
 ### Setting up Cloudflare Pages
 
@@ -27,10 +27,9 @@ In other words, this setup closely resembels the [Hello World example](https://g
 
 1. Go to the Cloudflare dashboard.
 2. Navigate to the "Workers & Pages" section.
-3. Create a new project.
-4. Create a new project and connect it to your GitHub repository.
-5. During setup, select the appropriate branch (for example `main`) to deploy from.
-6. Ignore the build settings for now.
+3. Create a new project and connect it to your GitHub repository.
+4. During setup, select the appropriate branch (e.g. `main`) to deploy from.
+5. Ignore the build settings for now.
 
 #### Disable Automatic Deployments:
 
@@ -49,7 +48,7 @@ In other words, this setup closely resembels the [Hello World example](https://g
 4. Add a new `CLOUDFLARE_API_TOKEN` secret based on:
    - Go to "My Profile" from the top right dropdown menu.
    - Navigate to the "API Tokens" section.
-   - Create a new custom API token with the `Cloudflare Pages`: `Edit` permission.
+   - Create a new custom API token with the `Cloudflare Pages: Edit` permission.
    - Copy the API token and paste it as the secret value.
 
 #### Create a GitHub Actions Workflow

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -1,27 +1,107 @@
 # 04 SPA deployments
 
-If you have built a Lustre application that doesn't have a backend you need to
-deploy, you can use a number of static hosting services to get your SPA online.
-In this guide we'll look at three options, Cloudflare Pages, GitHub Pages and Netlify.
+If you have built a Lustre application that doesn't have a backend you need to deploy, you can use a number of static hosting services to get your SPA online. In this guide we'll look at two options, GitHub Pages and Cloudflare Pages, but the principles can be applied to other services as well.
 
 If you are planning on building and deploying a full stack Gleam project, you
 probably don't want to follow this guide!
 
-## Deploying with Cloudflare Pages
+## Prerequisites
 
-There are multiple ways to deploy a Lustre SPA with Cloudflare Pages. For this guide we will focus on automated deployments using GitHub Actions. We will opt out of Cloudflare's "Automatic Deployments" since it does not support Gleam and/or Lustre. Instead, we build our application with `lustre_dev_tools` and use the Wrangler action to deploy our application.
-
-In this guide we also assume that you build your Lustre application with:
+In this guide we assume that you can build your Lustre SPA with `lustre_dev_tools`:
 
 ```
-gleam run -m lustre/dev build app
+gleam run -m lustre/dev build app --minify
 ```
 
-and that this results in a `priv/static` directory in your repository root directory. The built application is then loaded in a `<script>` tag in your HTML file (`index.html`), located in your repository root directory.
+and that this results in an application `priv/static` directory in your repository root directory. The built application is then loaded in a `<script>` tag in an HTML file `index.html` located in your repository root directory.
 
 In other words, this project setup closely resembles the [Hello World example](https://github.com/lustre-labs/lustre/tree/main/examples/01-hello-world).
 
 > **Note**: when using the `--minify` flag in the build command, remember to update your `<script>` tag in `index.html` to point to the minified file. In the Hello World example, this would be `/priv/static/app.min.mjs` instead of `/priv/static/app.mjs`.
+
+Finally, we also assume that you have a GitHub repository set up for your Lustre application.
+
+## Deploying with GitHub Pages
+
+There are multiple ways to deploy a Lustre SPA with GitHub Pages. For this guide we will focus on automated deployments using GitHub Actions. We will build our application with `lustre_dev_tools` and use the GitHub Actions workflow to deploy our application.
+
+### Setting up GitHub Pages
+
+1. Go to your repository settings on GitHub.
+2. Navigate to the Pages section.
+3. Set the source to GitHub Actions.
+
+### Setting up GitHub Actions
+
+#### Create a GitHub Actions Workflow
+
+Create a new file in your repository at `.github/workflows/deploy.yml` and use the following template as a starting point:
+
+```yaml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Gleam
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27.0"
+          gleam-version: "1.4.1"
+          rebar3-version: "3"
+      - name: Install dependencies
+        run: gleam deps download
+      - name: Build app
+        run: gleam run -m lustre/dev build app --minify
+      - name: Copy output to dist
+        run: |
+          mkdir -p dist
+          cp index.github.html dist/index.html
+          cp -r priv dist/priv
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "dist"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+Make sure to update the Gleam and OTP versions to match your project's requirements.
+
+This workflow:
+
+- Installs Gleam and its dependencies.
+- Builds the Lustre application.
+- Copies the built application to a `dist/` directory.
+- Uploads the `dist/` directory as an artifact.
+- Deploys the artifact to GitHub Pages.
+
+### Deploying
+
+After setting up the GitHub Actions workflow, you can now push your changes to the `main` branch to trigger a deployment to GitHub Pages.
+
+Your application should now be available at the GitHub Pages URL, which is usually `https://<username>.github.io/<repository>`.
+
+## Deploying with Cloudflare Pages
+
+There are multiple ways to deploy a Lustre SPA with Cloudflare Pages. For this guide we will focus on automated deployments using GitHub Actions. We will opt out of Cloudflare's "Automatic Deployments" since it does not support Gleam and/or Lustre. Instead, we build our application with `lustre_dev_tools` (similar to the GitHub pages guide above) and use the Wrangler action to deploy our application.
 
 ### Setting up Cloudflare Pages
 
@@ -111,12 +191,4 @@ This workflow:
 
 After setting up the GitHub Actions workflow, you can now push your changes to the `main` branch to trigger a deployment to Cloudflare Pages.
 
-Your application should now be available at the Cloudflare Pages URL!
-
-## Deploying with GitHub Pages
-
-🚧
-
-## Deploying with Netlify
-
-🚧
+Your application should now be available at the Cloudflare Pages URL, which is usually `https://<project-name>.pages.dev`.

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -100,10 +100,11 @@ jobs:
 Make sure to replace `<YOUR_PROJECT_NAME>` with the name of your Cloudflare Pages project and also to update the Gleam and OTP versions to match your project's requirements.
 
 This workflow:
-  - Installs Gleam and its dependencies.
-  - Builds the Lustre application.
-  - Copies the built application to a `dist/` directory.
-  - Deploys the `dist/` directory to Cloudflare Pages using Wrangler.
+
+- Installs Gleam and its dependencies.
+- Builds the Lustre application.
+- Copies the built application to a `dist/` directory.
+- Deploys the `dist/` directory to Cloudflare Pages using Wrangler.
 
 ### Deploying
 

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -12,11 +12,11 @@ In this guide we assume that you can build your Lustre SPA with `lustre_dev_tool
 gleam run -m lustre/dev build app --minify
 ```
 
-and that this results in an application `priv/static` directory in your repository root directory. The built application is then loaded in a `<script>` tag in an HTML file `index.html` located in your repository root directory.
+and that this results in an application in your `priv/static` directory in your repository root directory. The built application is then loaded in a `<script>` tag in an HTML file `index.html` located in your repository root directory.
 
 In other words, this project setup closely resembles the [Hello World example](https://github.com/lustre-labs/lustre/tree/main/examples/01-hello-world).
 
-> **Note**: when using the `--minify` flag in the build command, remember to update your `<script>` tag in `index.html` to point to the minified file. In the Hello World example, this would be `/priv/static/app.min.mjs` instead of `/priv/static/app.mjs`.
+> **Note**: when using the `--minify` flag in the build command, we need to update the `<script>` tag in `index.html` to point to the minified file. In the Hello World example, this would be `/priv/static/app.min.mjs` instead of `/priv/static/app.mjs`. In the GitHub Action workflows below we have automated this step with a `sed`-command. In this command, we also assumed that your app is called `app` just like in the Hello World example, so if your app has a different name you need to update the command accordingly.
 
 Finally, we also assume that you have a GitHub repository set up for your Lustre application.
 
@@ -73,6 +73,8 @@ jobs:
           mkdir -p dist
           cp index.html dist/index.html
           cp -r priv dist/priv
+      - name: Update path in index.html to use minified app
+        run: sed -i 's|priv/static/app.mjs|priv/static/app.min.mjs|' dist/index.html
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
@@ -84,7 +86,7 @@ jobs:
         uses: actions/deploy-pages@v4
 ```
 
-> **Note**: Make sure to update the Gleam and OTP versions to match your project's requirements.
+> **Note**: Make sure to update the Gleam and OTP versions to match your project's requirements. Also verify that the app name used in the `sed`-command matches the name of your application.
 
 This workflow:
 
@@ -171,6 +173,8 @@ jobs:
           mkdir -p dist
           cp index.html dist/index.html
           cp -r priv dist/priv
+      - name: Update path in index.html to use minified app
+        run: sed -i 's|priv/static/app.mjs|priv/static/app.min.mjs|' dist/index.html
       - name: Deploy with Wrangler
         uses: cloudflare/wrangler-action@v3
         with:
@@ -179,7 +183,7 @@ jobs:
           command: pages deploy dist --project-name <YOUR_PROJECT_NAME>
 ```
 
-> **Note**: Make sure to replace `<YOUR_PROJECT_NAME>` with the name of your Cloudflare Pages project and also to update the Gleam and OTP versions to match your project's requirements.
+> **Note**: Make sure to replace `<YOUR_PROJECT_NAME>` with the name of your Cloudflare Pages project and also to update the Gleam and OTP versions to match your project's requirements. Also verify that the app name used in the `sed`-command matches the name of your application.
 
 This workflow:
 

--- a/pages/guide/04-spa-deployments.md
+++ b/pages/guide/04-spa-deployments.md
@@ -21,6 +21,8 @@ and that this results in a `priv/static` directory in your repository root direc
 
 In other words, this project setup closely resembles the [Hello World example](https://github.com/lustre-labs/lustre/tree/main/examples/01-hello-world).
 
+> **Note**: when using the `--minify` flag in the build command, remember to update your `<script>` tag in `index.html` to point to the minified file. In the Hello World example, this would be `/priv/static/app.min.js` instead of `/priv/static/app.js`.
+
 ### Setting up Cloudflare Pages
 
 #### Create a Cloudflare Pages Project:


### PR DESCRIPTION
update: I added GitHub Pages in this patch as well 🙂

here is the companion demo repo that I used to make sure it works:
https://github.com/ollema/lustre-spa-deployment

and the associated workflows:
https://github.com/ollema/lustre-spa-deployment/blob/main/.github/workflows/github_pages.yml
https://github.com/ollema/lustre-spa-deployment/blob/main/.github/workflows/cloudflare_pages.yml

and the resulting deployments:
https://ollema.github.io/lustre-spa-deployment/
https://lustre-spa-deployment.pages.dev/

let me know if I missed anything!

some thoughts:
- I'm including a build step here in the workflow but it is not strictly needed if you have not .gitignored the priv/ directory but then it's up to the user to remember to build before you push. could simplify the workflow a lot if we only want to deploy files that are already built and tracked in VCS. but I think it's nicer to already have the build step in place if you need it in the future.
- I'm not sure if copying files to `dist/` is "idiomatic Lustre" but I figured it could be a nice touch to reduce the risk of accidentally deploying files you did not mean too. maybe there is some Cloudflare/GitHub pages specific .ignore file that could be used but I find that this is a more general solution that would work for other services as well. can change to not include this step if you want and deploy straight from the project root.