### PR TITLE
Fix `accept` using incorrect separator

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -152,7 +152,7 @@ pub fn selected(is_selected: Bool) -> Attribute(msg) {
 
 ///
 pub fn accept(types: List(String)) -> Attribute(msg) {
-  attribute("accept", string.join(types, " "))
+  attribute("accept", string.join(types, ","))
 }
 
 ///


### PR DESCRIPTION
Replaced ` ` (space) with `,` (comma), as the valid attribute value is set of comma-separated token.

spec: <https://html.spec.whatwg.org/multipage/input.html#attr-input-accept>