### PR TITLE
:bug: After iterating, clean up fragment elements that will be unused #160

### DIFF
--- a/src/vdom.ffi.mjs
+++ b/src/vdom.ffi.mjs
@@ -76,6 +76,14 @@ export function morph(prev, next, dispatch, isComponent = false) {
         stack.unshift({ prev, next: fragmentElement, parent });
         prev = prev?.nextSibling;
       });
+      // Remove extra elements no longer in use from the top-level fragment elements
+      // if next is Fragment([div,div,div]) and prev is <div></div><div></div><div></div><div></div>
+      // this will remove the elements that would be unused
+      while (prev) {
+        const currPrev = prev;
+        prev = currPrev.nextSibling;
+        currPrev.remove();
+      }
     } else if (next.subtree !== undefined) {
       stack.push({ prev, next, parent });
     }


### PR DESCRIPTION
### Summary

When using a top level fragment such as:
```
fn view(model: Model) -> Element(Msg) {
  element.fragment([
    // html.div([], [
    ui.button([event.on_click(AddRow)], [element.text("Add")]),
    html.table([], [
      html.thead([], [
        html.tr([], [
          html.td([], [element.text("id")]),
          html.td([], [element.text("name")]),
        ]),
      ]),
    ]),
    element.fragment(list.map(model.rows, render_row)),
  ])
}
```
The reflected DOM will include some number of rows. On re-render, if the number of rows is less than the previous instance today the vdom will not clean up the hanging elements after re-rendering the rows that should exist.
After iterating through a top-level fragment, all previous siblings have been accounted for in this new iteration, so in order to clean up superfluous elements, remove all until `prev` is not truthy. This resolves the issue of handing elements. 

TODO: `Add images`

| | Before | After |
|-|--------|-------|
| | <img width="480" src="https://github.com/user-attachments/assets/a81ded31-b4b5-446f-9ff9-8c3a849659c3" /> | <img width="480" src="https://github.com/user-attachments/assets/cd38b04e-ed4c-4858-80c0-1364e6b396bf" /> |


