### PR TITLE
:recycle: Replace deprecated unsafe_coerce calls

### DIFF
--- a/src/lustre-escape.ffi.mjs
+++ b/src/lustre-escape.ffi.mjs
@@ -9,3 +9,7 @@ export function first(string) {
 export function drop_first(string) {
   return string.slice(1);
 }
+
+export function coerce(x) {
+  return x;
+}

--- a/src/lustre/internals/patch.gleam
+++ b/src/lustre/internals/patch.gleam
@@ -350,11 +350,7 @@ fn attribute_dict(
       case dict.get(dict, "class") {
         Ok(Attribute(_, classes, _)) -> {
           let classes =
-            dynamic.from(
-              dynamic.unsafe_coerce(classes)
-              <> " "
-              <> dynamic.unsafe_coerce(value),
-            )
+            dynamic.from(unsafe_coerce(classes) <> " " <> unsafe_coerce(value))
           dict.insert(dict, "class", Attribute("class", classes, False))
         }
 
@@ -366,8 +362,8 @@ fn attribute_dict(
         Ok(Attribute(_, styles, _)) -> {
           let styles =
             dynamic.from(list.append(
-              dynamic.unsafe_coerce(styles),
-              dynamic.unsafe_coerce(value),
+              unsafe_coerce(styles),
+              unsafe_coerce(value),
             ))
           dict.insert(dict, "style", Attribute("style", styles, False))
         }
@@ -437,3 +433,9 @@ pub fn is_empty_element_diff(diff: ElementDiff(msg)) -> Bool {
 fn is_empty_attribute_diff(diff: AttributeDiff(msg)) -> Bool {
   diff.created == set.new() && diff.removed == set.new()
 }
+
+// FFI -------------------------------------------------------------------------
+
+@external(erlang, "lustre_escape_ffi", "coerce")
+@external(javascript, "../../../lustre-escape.ffi.mjs", "coerce")
+fn unsafe_coerce(value: a) -> b

--- a/src/lustre/internals/runtime.gleam
+++ b/src/lustre/internals/runtime.gleam
@@ -135,7 +135,7 @@ fn loop(
     }
 
     Debug(ForceModel(model)) -> {
-      let model = dynamic.unsafe_coerce(model)
+      let model = unsafe_coerce(model)
       let html = state.view(model)
       let diff = patch.elements(state.html, html)
       let next =
@@ -235,3 +235,9 @@ fn run_effects(effects: Effect(msg), self: Subject(Action(msg, runtime))) -> Nil
 
   effect.perform(effects, dispatch, emit)
 }
+
+// FFI -------------------------------------------------------------------------
+
+@external(erlang, "lustre_escape_ffi", "coerce")
+@external(javascript, "../../../lustre-escape.ffi.mjs", "coerce")
+fn unsafe_coerce(value: a) -> b

--- a/src/lustre/internals/vdom.gleam
+++ b/src/lustre/internals/vdom.gleam
@@ -124,7 +124,7 @@ pub fn attribute_to_json(
           Ok(
             json.object([
               #("0", json.string(name)),
-              #("1", json.string(dynamic.unsafe_coerce(value))),
+              #("1", json.string(unsafe_coerce(value))),
             ]),
           )
 
@@ -132,7 +132,7 @@ pub fn attribute_to_json(
           Ok(
             json.object([
               #("0", json.string(name)),
-              #("1", json.bool(dynamic.unsafe_coerce(value))),
+              #("1", json.bool(unsafe_coerce(value))),
             ]),
           )
 
@@ -140,7 +140,7 @@ pub fn attribute_to_json(
           Ok(
             json.object([
               #("0", json.string(name)),
-              #("1", json.bool(dynamic.unsafe_coerce(value))),
+              #("1", json.bool(unsafe_coerce(value))),
             ]),
           )
 
@@ -148,7 +148,7 @@ pub fn attribute_to_json(
           Ok(
             json.object([
               #("0", json.string(name)),
-              #("1", json.int(dynamic.unsafe_coerce(value))),
+              #("1", json.int(unsafe_coerce(value))),
             ]),
           )
 
@@ -156,7 +156,7 @@ pub fn attribute_to_json(
           Ok(
             json.object([
               #("0", json.string(name)),
-              #("1", json.float(dynamic.unsafe_coerce(value))),
+              #("1", json.float(unsafe_coerce(value))),
             ]),
           )
 
@@ -397,3 +397,9 @@ pub fn attribute_to_event_handler(
     }
   }
 }
+
+// FFI -------------------------------------------------------------------------
+
+@external(erlang, "lustre_escape_ffi", "coerce")
+@external(javascript, "../../../lustre-escape.ffi.mjs", "coerce")
+fn unsafe_coerce(value: a) -> b


### PR DESCRIPTION
This PR replaces all calls to the deprecated `dynamic.unsafe_coerce` with an external function.