### PR TITLE
docs: fix quickstart link

### DIFF
--- a/src/lustre.gleam
+++ b/src/lustre.gleam
@@ -2,7 +2,7 @@
 //// Gleam. This module contains the core API for constructing and communicating
 //// with Lustre applications. If you're new to Lustre or frontend development in
 //// general, make sure you check out the [examples](https://github.com/lustre-labs/lustre/tree/main/examples)
-//// or the [quickstart guide]() to get up to speed!
+//// or the [quickstart guide](./guide/01-quickstart.html) to get up to speed!
 ////
 //// Lustre currently has three kinds of application:
 ////


### PR DESCRIPTION
I'm new to lustre and this was the first link to the quickstart guide I tried. Took a few minutes to try to find the right one. Hopefully this small fix helps other beginners!

Appears on this page: https://hexdocs.pm/lustre/lustre.html