### PR TITLE
:bug: Fixed element.keyed children

### DIFF
--- a/src/vdom.ffi.mjs
+++ b/src/vdom.ffi.mjs
@@ -589,11 +589,8 @@ function diffKeyedChild(
   // insert the incoming child at the current position (and diff against whatever
   // is already there).
   if (keyedChildren.size === 0) {
-    for (const currChild of children(child)) {
-      stack.unshift({ prev: prevChild, next: currChild, parent: el });
-      prevChild = prevChild?.nextSibling;
-    }
-
+    stack.unshift({ prev: prevChild, next: child, parent: el });
+    prevChild = prevChild?.nextSibling;
     return prevChild;
   }
 


### PR DESCRIPTION
Fixed the problem where children of element.keyed elements would be added instead of the elements themselves.

It seems like the problem was a for-loop looping though the children of each child and adding them instead of the child itself when there were no keyed children.   
I left the `prevChild` behaviour because I am not sure of how it works.   
Also, I guess the for-loop was here for a reason, so I hope the change doesn't break anything. It does appear to fix the problem though