### PR TITLE
Clarify SSR Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,16 @@
 
 ## Features
 
+- **Unparalleled flexibility.** Run in the browser, render on the server, or diff
+  over the wire **only where you need it**. Elm meets Phoenix LiveView.
+
 - A **declarative**, functional API for constructing HTML. No templates, no macros,
   just Gleam.
 
-- An Erlang and Elm-inspired architecture for **managing state**.
-
-- **Managed side effects** for predictable, testable code.
-
-- Universal components. **Write once, run anywhere**. Elm meets Phoenix LiveView.
+- An Erlang and Elm-inspired state architecture with **Managed side effects**
+  for predictable, testable code.
 
 - A **batteries-included CLI** that makes scaffolding and building apps a breeze.
-
-- **Server-side rendering** for static HTML templating.
 
 ## Example
 

--- a/pages/guide/05-server-side-rendering.md
+++ b/pages/guide/05-server-side-rendering.md
@@ -3,7 +3,14 @@
 Up until now, we have focused on Lustre's ability as a framework for building
 Single Page Applications (SPAs). While Lustre's development and feature set is
 primarily focused on SPA development, that doesn't mean it can't be used on the
-backend as well! In this guide we'll set up a small [mist](https://hexdocs.pm/mist/)
+backend as well!
+
+Lustre can render on the server in two ways:
+
+1. Server Side Rendering, where the full rendered view is sent
+2. Server Components, which exchange diffs with the client
+
+In this guide we'll start with the former by setting up a small [mist](https://hexdocs.pm/mist/)
 server that renders some static HTML using Lustre.
 
 ## Setting up the project

--- a/pages/guide/06-full-stack-applications.md
+++ b/pages/guide/06-full-stack-applications.md
@@ -5,9 +5,10 @@
 
 # 06 Full stack applications
 
-We've now seen how Lustre can render single-page applications in the browser,
-static HTML templates, and we've seen how hydration can be implemented. In this
-guide we'll look at how to put these pieces together into a single application.
+We've seen how Lustre can render single-page applications in the browser, and
+static HTML templates on the server, powered-up with hydration. In this guide
+we'll look at how to put these pieces together and create our first full stack
+application, before continuing to Server Components and truly combining the two.
 
 To create a full stack Web application in Gleam you will need to adopt a
 _monorepo_. Although Gleam supports multiple targets, and has conditional

--- a/pages/guide/08-components.md
+++ b/pages/guide/08-components.md
@@ -4,7 +4,7 @@
 > creating components with Lustre.
 
 
-# 06 Components
+# 08 Components
 
 In the previous chapters of this guide we have explored the Model-View-Update
 architecture and stressed the importance of having a _single source of truth_ in


### PR DESCRIPTION
While reading the Lustre guide, I mistook the `Server Side Rendering` page as the only way to do SSR, and then didn't continue to read Server Components.

These PR remedies this by changing the three main places in which a potential user is introduced to SSR: the features section in the readme, and the two relevant guides.

For the readme, I've changed the features more for the new phrasing to flow better with the rest of them, feel free to change yourself or ask for changes.

For the guides, I've clearly separated the two modes of SSR, but the naming is still a bit confusing. I would at the very least change "Server Side Rendering" to more specific title, although I could not come up with one.
