### PR TITLE
Add docs about rendering lists

### DIFF
--- a/pages/guide/01-quickstart.md
+++ b/pages/guide/01-quickstart.md
@@ -388,6 +388,12 @@ pub fn view(model: Model) -> element.Element(Msg) {
 }
 ```
 
+> **Note**: Depending on how fast the cat images download, and your browser window
+> size and zoom level, you might notice that when you click the increment counter
+> that the last cat image is duplicated before the new image loads. This is expected.
+> To learn more about why this happens and how to prevent this behaviour, see
+> [rendering lists](https://github.com/lustre-labs/lustre/blob/main/pages/hints/rendering-lists.md)
+
 ## Where to go from here
 
 Believe it or not, you've already seen about 80% of what Lustre has to offer! From

--- a/pages/guide/01-quickstart.md
+++ b/pages/guide/01-quickstart.md
@@ -258,8 +258,6 @@ effects, but for now we'll use a community package called
 every time the counter is incremented.
 
 Because this is a separate package, make sure to add it to your project first.
-While we're here, we'll also add `gleam_json` so we can decode the response from
-the cat API:
 
 ```sh
 $ gleam add lustre_http

--- a/pages/hints/rendering-lists.md
+++ b/pages/hints/rendering-lists.md
@@ -1,0 +1,131 @@
+# Rendering lists
+
+Items in a list can change position, for example when sorting or filtering, or
+when adding or removing items. When this happens, the view will re-render, resulting
+in a new virtual DOM which is then diffed with the existing DOM to determine what
+changes are required to be made. As a result of this process you might see some
+unexpected visual issues. These issues are not unique to Lustre and can be reproduced
+in other frameworks that use a virtual DOM. For example, here is what React has to
+[say about this](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key).
+
+We'll explore a visual issue example below, but the quick solution to this issue
+is to use the [`element.keyed`](https://hexdocs.pm/lustre/lustre/element.html#keyed)
+function so Lustre can more accurately track which items in a list have changed.
+
+## Seeing double
+
+One example of a visual issue can be seen in the [quickstart program](../guide/01-quickstart.md)
+where it is possible to briefly see a duplicated cat image before the new image has
+completely loaded. Let's walk through why this happens.
+
+When you first click the increment button, the http side effect will eventually
+cause a cat image slug, let's call it `a`, to be added the model's `cat` list.
+The view will render a single image tag for this list, it will be added to the DOM,
+and the browser will make a request for this image, displaying it once it has completed
+downloading.
+
+When the increment button is clicked a second time, the http side effect will
+eventually cause a cat image slug, let's call it `b`, to be [added to the front](https://tour.gleam.run/basics/lists/)
+of the model's `cat` list. So this list has changed from `[a]` to `[b, a]`. The view
+will now render two image tags, first for `b` and then for `a`, as it walks the list.
+When this virtual DOM is diffed with the current DOM, it looks like the image tag
+that used to show `a` has been changed to show `b`, and a new image tag for `a` has
+been added as a sibling element. This causes the browser to request image `b`, but while
+that is downloading, the previous image shown on screen for this tag remains visible.
+Also while `b` is downloading, the browser needs to show the image `a` for new tag.
+This can be pulled from the browser cache so is immediately displayed without the user
+experiencing any delay. The visual issue presents as a duplicate `a` cat image until
+image `b` is downloaded, at which point it replaces the first `a` image.
+
+To try and represent this in a different way:
+
+```
+Increment ->                 Increment ->
+             <img href="a">  --changes-->  <img href="b">
+                             -- added -->  <img href="a">
+```
+
+> **Note:** Because the cat API returns a random image, it is possible for the final
+> result to be a duplicate cat image. This is a different situation from the one
+> described above. Using the slugs from above, this situation would produce
+> a list `[a, a]`.
+
+### Fixing the quickstart program
+
+As mentioned in the first section above, the way to fix this issue is to [key the
+elements](https://hexdocs.pm/lustre/lustre/element.html#keyed). This allows Lustre
+to better track which items have changed, moved, been removed, etc. Keyed elements
+were intentionally not used in the quickstart tutorial in an attempt to focus on
+the fundamentals.
+
+The key must be unique within a list, and the cat API could return the same image
+since it's random. This means the image slug is not suitable for use as a key.
+One solution is to make a synthetic key and pass it around as part of the model.
+This means we don't have to add additional depenencies such as a UUID library.
+
+> **Note:** Lustre will display a warning in the browser console when it detects
+> duplicate keys.
+
+Update the model so it carries the next synthetic id. The list of cats now also includes
+an `id` along with the URL slug, which will be used as the element key:
+
+```gleam
+pub type Model {
+  Model(count: Int, cats: List(#(Int, String)), next_id: Int)
+}
+```
+
+The `init` function needs updating for the new model constructor:
+
+```gleam
+fn init(_flags) -> #(Model, effect.Effect(Msg)) {
+  #(Model(0, [], 0), effect.none())
+}
+```
+
+In the `update` function, during the `ApiReturnedCat(Ok(cat))` message match, the
+`next_id` is used when adding the new cat to the list. The `next_id` is also 
+incremented so any subsequent uses of it will have a new value. The 
+`UserDecrementedCount` message match needs to be updated to support the new model
+constructor also.
+
+```gleam
+pub fn update(model: Model, msg: Msg) -> #(Model, effect.Effect(Msg)) {
+  case msg {
+    UserIncrementedCount -> #(Model(..model, count: model.count + 1), get_cat())
+    UserDecrementedCount -> #(
+      Model(model.count - 1, list.drop(model.cats, 1), model.next_id),
+      effect.none(),
+    )
+    ApiReturnedCat(Ok(cat)) -> #(
+      Model(model.count, [#(model.next_id, cat), ..model.cats], model.next_id + 1),
+      effect.none(),
+    )
+    ApiReturnedCat(Error(_)) -> #(model, effect.none())
+  }
+}
+```
+
+Finally, update the `view` function to use `element.keyed`:
+
+```gleam
+pub fn view(model: Model) -> element.Element(Msg) {
+  let count = int.to_string(model.count)
+
+  html.div([], [
+    html.button([event.on_click(UserIncrementedCount)], [element.text("+")]),
+    element.text(count),
+    html.button([event.on_click(UserDecrementedCount)], [element.text("-")]),
+    element.keyed(
+      html.div([], _),
+      list.map(model.cats, fn(item) {
+        let #(id, cat) = item
+        #(
+          int.to_string(id),
+          html.img([attribute.src("https://cataas.com/cat/" <> cat)]),
+        )
+      }),
+    ),
+  ])
+}
+```

--- a/pages/hints/rendering-lists.md
+++ b/pages/hints/rendering-lists.md
@@ -98,7 +98,11 @@ pub fn update(model: Model, msg: Msg) -> #(Model, effect.Effect(Msg)) {
       effect.none(),
     )
     ApiReturnedCat(Ok(cat)) -> #(
-      Model(model.count, [#(model.next_id, cat), ..model.cats], model.next_id + 1),
+      Model(
+        model.count,
+        [#(model.next_id, cat), ..model.cats],
+        model.next_id + 1,
+      ),
       effect.none(),
     )
     ApiReturnedCat(Error(_)) -> #(model, effect.none())

--- a/pages/hints/rendering-lists.md
+++ b/pages/hints/rendering-lists.md
@@ -37,7 +37,12 @@ This can be pulled from the browser cache so is immediately displayed without th
 experiencing any delay. The visual issue presents as a duplicate `a` cat image until
 image `b` is downloaded, at which point it replaces the first `a` image.
 
-To try and represent this in a different way:
+> **Note:** Because the cat API returns a random image, it is possible for the final
+> result to be a duplicate cat image. This is a different situation from the one
+> described above. Using the slugs from above, this situation would produce
+> a list `[a, a]`.
+
+To try and represent this in a different way by showing how the DOM might change:
 
 ```
 Increment ->                 Increment ->
@@ -45,10 +50,14 @@ Increment ->                 Increment ->
                              -- added -->  <img href="a">
 ```
 
-> **Note:** Because the cat API returns a random image, it is possible for the final
-> result to be a duplicate cat image. This is a different situation from the one
-> described above. Using the slugs from above, this situation would produce
-> a list `[a, a]`.
+With `element.keyed`, these changes might look more like:
+    
+```
+Increment ->                 Increment ->
+                             -- added -->  <img href="b">
+             <img href="a">  -no change->  <img href="a">
+```
+
 
 ### Fixing the quickstart program
 

--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -156,7 +156,8 @@ pub fn element(
 ///
 /// **Note**: The key must be unique within the list of children, but it doesn't
 /// have to be unique across the whole application. It's fine to use the same key
-/// in different lists.
+/// in different lists. Lustre will display a warning in the browser console when
+/// it detects duplicate keys in a list.
 ///
 ///
 pub fn keyed(


### PR DESCRIPTION
This PR adds docs for considerations around rendering lists, discussing the duplicate image issue that can be seen in the quickstart tutorial, and how to solve this using `element.keyed`.

The quickstart tutorial page has a brief note explaining this, with a link to the new docs. Currently the docs are in the `hints` folder. I think all the `hints` docs probably warrant becoming links in the main `pages` menu of the docs, even if they remain in the `hints` folder (or add a `hints` menu section if that's possible). This increases their visibility (I only found the two exisiting hints from browsing the repo). This piece of work is not yet done, since I'm unsure if you'd prefer to structure the menu or file locations.

You are most welcome to change/edit any of the docs I've created to fit any preferred writing style, or otherwise change as desired. It's probably worth a check that my proposed solution to the quickstart tutorial duplicate image issue is a correct one
