### PR TITLE
:rotating_light: Update gleam version constraint

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,6 @@
 name = "lustre"
 version = "4.4.4"
-gleam = ">= 1.0.0"
+gleam = ">= 1.1.0"
 
 description = "An Gleam web framework for building HTML templates, single page applications, and real-time server components."
 repository = { type = "github", user = "lustre-labs", repo = "lustre" }


### PR DESCRIPTION
Lustre uses the internal annotation so it requires a gleam version that is at least >= 1.1.0 to compile