### PR TITLE
Fix: Rely on thecatapi.com for 01-Quickstart page examples

### DIFF
--- a/pages/guide/01-quickstart.md
+++ b/pages/guide/01-quickstart.md
@@ -341,12 +341,10 @@ pub fn update(model: Model, msg: Msg) -> #(Model, effect.Effect(Msg)) {
   case msg {
     UserIncrementedCount -> #(Model(..model, count: model.count + 1), get_cat())
     UserDecrementedCount -> #(Model(..model, count: model.count - 1), effect.none())
-    ApiReturnedCats(Ok(api_cats)) ->
-      case api_cats {
-        [] -> #(model, effect.none())
-
-        [cat, ..] -> #(Model(..model, cats: [cat, ..model.cats]), effect.none())
-      }
+    ApiReturnedCats(Ok(api_cats)) -> {
+      let assert [cat, ..] = api_cats
+      #(Model(..model, cats: [cat, ..model.cats]), effect.none())
+    }
     ApiReturnedCats(Error(_)) -> #(model, effect.none())
   }
 }


### PR DESCRIPTION
The application compiles for the user when building examples from the [01-quickstart](https://hexdocs.pm/lustre/guide/01-quickstart.html) page, but sadly, no cats appear due to the previous random cat API's availability (often, slow or no response).

The new API seems to work better, though since it returns a list with one cat by default, slightly more complex code was necessary to accommodate the differing response shape.  (A good learning experience for me.)