### PR TITLE
Change toml file to accept installing gleam_json@2 in your lustre project

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -34,7 +34,7 @@ pages = [
 
 [dependencies]
 gleam_erlang = "~> 0.24"
-gleam_json = "~> 1.0"
+gleam_json = ">= 1.0.0 and < 3.0.0"
 gleam_otp = "~> 0.9"
 gleam_stdlib = "~> 0.36"
 


### PR DESCRIPTION
https://discord.com/channels/768594524158427167/768594524158427170/1299056516170514442

i wanted to use gleam json in my lustre project

this PR is just to show the issue not the fix also this package 

- gleam_community_colour

has the same issue the lustre package have and lustre depends on it