### PR TITLE
Fix property readonly.

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -192,7 +192,7 @@ pub fn pattern(regex: String) -> Attribute(msg) {
 
 ///
 pub fn readonly(is_readonly: Bool) -> Attribute(msg) {
-  property("readonly", is_readonly)
+  property("readOnly", is_readonly)
 }
 
 ///


### PR DESCRIPTION
The property is actually named "readOnly" rather than "readonly". This fixes #201.

Verified with the following code snippet:

```gleam
pub fn main() {
  let app = lustre.element(html.input([attribute.property("readOnly", True)]))
  let assert Ok(_) = lustre.start(app, "#app", Nil)

  Nil
}
```