### PR TITLE
Fixed minor doc error for full-stack guide

### DIFF
--- a/pages/guide/06-full-stack-applications.md
+++ b/pages/guide/06-full-stack-applications.md
@@ -17,8 +17,10 @@ _three separate Gleam projects_:
 
 ```sh
 mkdir lustre-fullstack-guide \
+  && cd lustre-fullstack-guide \
   && gleam new client --name app \
-  && gleam new server --name app
+  && gleam new server --name app \
+  && gleam new shared --name app
 ```
 
 We have one project for the frontend SPA, one project for the server, and a third


### PR DESCRIPTION
I think this command was intended to be:
```sh
mkdir lustre-fullstack-guide \
  && cd lustre-fullstack-guide \
  && gleam new client --name app \
  && gleam new server --name app \
  && gleam new shared --name app
```