### PR TITLE
Decrement msg should remove an image

### DIFF
--- a/pages/guide/01-quickstart.md
+++ b/pages/guide/01-quickstart.md
@@ -340,7 +340,10 @@ counter is incremented and handle the response:
 pub fn update(model: Model, msg: Msg) -> #(Model, effect.Effect(Msg)) {
   case msg {
     UserIncrementedCount -> #(Model(..model, count: model.count + 1), get_cat())
-    UserDecrementedCount -> #(Model(..model, count: model.count - 1), effect.none())
+    UserDecrementedCount -> #(
+      Model(count: model.count - 1, cats: list.drop(model.cats, 1)),
+      effect.none(),
+    )
     ApiReturnedCats(Ok(api_cats)) -> {
       let assert [cat, ..] = api_cats
       #(Model(..model, cats: [cat, ..model.cats]), effect.none())


### PR DESCRIPTION
When following the quickstart script, I found that the increment button behaved correctly, but clicking the decrement button reduced the count without removing an image.

