### PR TITLE
Add attribute.data helper function

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -107,6 +107,14 @@ pub fn classes(names: List(#(String, Bool))) -> Attribute(msg) {
 }
 
 ///
+///
+/// Add a `data-*` attribute to an HTML element. The key will be prefixed by `data-`.
+/// 
+pub fn data(key: String, value: String) -> Attribute(msg) {
+  attribute("data-" <> key, value)
+}
+
+///
 pub fn id(name: String) -> Attribute(msg) {
   attribute("id", name)
 }


### PR DESCRIPTION
Small PR to add an `attribute.data/2` helper function to add data attributes to HTML elements. I added some small doc but I feel like it would benefit from some improvement.