### PR TITLE
Allows setting link crossorigin integrity attributes

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -274,6 +274,16 @@ pub fn rel(relationship: String) -> Attribute(msg) {
   attribute("rel", relationship)
 }
 
+///
+pub fn crossorigin(origin: String) -> Attribute(msg) {
+  attribute("crossorigin", origin)
+}
+
+///
+pub fn integrity(cryptographic_hash: String) -> Attribute(msg) {
+  attribute("integrity", cryptographic_hash)
+}
+
 // EMBEDDED CONTENT ------------------------------------------------------------
 
 ///


### PR DESCRIPTION
This PR add 2 new attributes that allows one to set the [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) and [`integrity`](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) attributes for `link` and `script` elements.