### PR TITLE
Adds the `lang` attribute

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -405,3 +405,10 @@ pub fn charset(name: String) -> Attribute(msg) {
 pub fn http_equiv(name: String) -> Attribute(msg) {
   attribute("http-equiv", name)
 }
+
+// HTML ------------------------------------------------------------------------
+
+///
+pub fn lang(name: String) -> Attribute(msg) {
+  attribute("lang", name)
+}


### PR DESCRIPTION
This allows us to do
```gleam
html[[lang("en")], [...]]
```