### PR TITLE
Virtualisation!

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -45,6 +45,11 @@ values now are required to be serialisable to a `json.Json` value.
 
 This change makes it possible to use `attribute.property` with server components.
 
+### `autoplay` and `autofocus` attributes now play and focus the element
+
+These attributes usually only work on page load. Lustre now special cases them
+to also trigger their associated action every time their value switches from
+`False` to `True`.
 
 ### Wrapper elements around fragments removed.
 

--- a/benchmarks/table-editor/src/column.gleam
+++ b/benchmarks/table-editor/src/column.gleam
@@ -140,12 +140,7 @@ pub fn register() {
       update,
       view,
       dict.from_list([
-        #("column", fn(column) {
-          case decode.run(column, decoder()) {
-            Ok(column) -> Ok(ParentUpdatedColumn(column))
-            Error(_) -> Error([])
-          }
-        }),
+        #("column", decode.map(decoder(), ParentUpdatedColumn))
       ]),
     )
 

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -144,7 +144,7 @@ pub fn value(val: String) -> Attribute(msg) {
 
 ///
 pub fn checked(is_checked: Bool) -> Attribute(msg) {
-  property("checked", json.bool(is_checked))
+  boolean_attribute("checked", is_checked)
 }
 
 ///
@@ -154,7 +154,7 @@ pub fn placeholder(text: String) -> Attribute(msg) {
 
 ///
 pub fn selected(is_selected: Bool) -> Attribute(msg) {
-  property("selected", json.bool(is_selected))
+  boolean_attribute("selected", is_selected)
 }
 
 // INPUT HELPERS ---------------------------------------------------------------
@@ -166,7 +166,7 @@ pub fn accept(types: List(String)) -> Attribute(msg) {
 
 ///
 pub fn accept_charset(types: List(String)) -> Attribute(msg) {
-  attribute("acceptCharset", string.join(types, " "))
+  attribute("accept-charset", string.join(types, " "))
 }
 
 ///
@@ -179,14 +179,17 @@ pub fn autocomplete(name: String) -> Attribute(msg) {
   attribute("autocomplete", name)
 }
 
+/// Sets the `autofocus` attribute.
 ///
+/// Lustre will focus the element every time this attribute switches from `False`
+/// to `True`.
 pub fn autofocus(should_autofocus: Bool) -> Attribute(msg) {
-  property("autofocus", json.bool(should_autofocus))
+  boolean_attribute("autofocus", should_autofocus)
 }
 
 ///
 pub fn disabled(is_disabled: Bool) -> Attribute(msg) {
-  property("disabled", json.bool(is_disabled))
+  boolean_attribute("disabled", is_disabled)
 }
 
 ///
@@ -201,12 +204,12 @@ pub fn pattern(regex: String) -> Attribute(msg) {
 
 ///
 pub fn readonly(is_readonly: Bool) -> Attribute(msg) {
-  property("readOnly", json.bool(is_readonly))
+  boolean_attribute("readonly", is_readonly)
 }
 
 ///
 pub fn required(is_required: Bool) -> Attribute(msg) {
-  property("required", json.bool(is_required))
+  boolean_attribute("required", is_required)
 }
 
 ///
@@ -311,19 +314,22 @@ pub fn content(text: String) -> Attribute(msg) {
 
 // AUDIO AND VIDEO -------------------------------------------------------------
 
+/// Sets the `autofocus` attribute.
 ///
+/// Lustre will start playing every time this attribute switches from `False`
+/// to `True`.
 pub fn autoplay(should_autoplay: Bool) -> Attribute(msg) {
-  property("autoplay", json.bool(should_autoplay))
+  boolean_attribute("autoplay", should_autoplay)
 }
 
 ///
 pub fn controls(visible: Bool) -> Attribute(msg) {
-  property("controls", json.bool(visible))
+  boolean_attribute("controls", visible)
 }
 
 ///
 pub fn loop(should_loop: Bool) -> Attribute(msg) {
-  property("loop", json.bool(should_loop))
+  boolean_attribute("loop", should_loop)
 }
 
 // FORMS -----------------------------------------------------------------------
@@ -345,7 +351,7 @@ pub fn method(method: String) -> Attribute(msg) {
 
 ///
 pub fn novalidate(value: Bool) -> Attribute(msg) {
-  property("novalidate", json.bool(value))
+  boolean_attribute("novalidate", value)
 }
 
 ///
@@ -365,7 +371,7 @@ pub fn form_method(method: String) -> Attribute(msg) {
 
 ///
 pub fn form_novalidate(value: Bool) -> Attribute(msg) {
-  property("formnovalidate", json.bool(value))
+  boolean_attribute("formnovalidate", value)
 }
 
 ///
@@ -377,7 +383,7 @@ pub fn form_target(target: String) -> Attribute(msg) {
 
 ///
 pub fn open(is_open: Bool) -> Attribute(msg) {
-  property("open", json.bool(is_open))
+  boolean_attribute("open", is_open)
 }
 
 // META ------------------------------------------------------------------------
@@ -390,4 +396,13 @@ pub fn charset(name: String) -> Attribute(msg) {
 ///
 pub fn http_equiv(name: String) -> Attribute(msg) {
   attribute("http-equiv", name)
+}
+
+// HELPERS ---------------------------------------------------------------------
+
+fn boolean_attribute(name: String, value: Bool) -> Attribute(msg) {
+  case value {
+    True -> attribute(name, "")
+    False -> none()
+  }
 }

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -108,7 +108,7 @@ pub fn classes(names: List(#(String, Bool))) -> Attribute(msg) {
       |> list.filter_map(fn(class) {
         case class.1 {
           True -> Ok(class.0)
-          False -> Error(Nil)
+          False -> constants.error_nil
         }
       })
       |> string.join(" "),

--- a/src/lustre/internals/constants.gleam
+++ b/src/lustre/internals/constants.gleam
@@ -62,3 +62,5 @@ pub fn empty_set() -> Set(a) {
 }
 
 pub const option_none = option.None
+
+pub const error_nil = Error(Nil)

--- a/src/lustre/runtime/client/reconciler.ffi.mjs
+++ b/src/lustre/runtime/client/reconciler.ffi.mjs
@@ -23,10 +23,6 @@ export class Reconciler {
     this.#dispatch = dispatch;
   }
 
-  mount(vnode) {
-    this.#root.appendChild(createElement(vnode, this.#dispatch, this.#root));
-  }
-
   push(patch) {
     this.#stack.push({ node: this.#root, patch });
     this.#reconcile();
@@ -92,7 +88,7 @@ export class Reconciler {
         }
       }
 
-      while (patch.removed-- > 0) {
+      for (let i = 0; i < patch.removed; ++i) {
         const child = node.lastChild;
         const key = child[meta].key;
 

--- a/src/lustre/runtime/client/virtualise.ffi.mjs
+++ b/src/lustre/runtime/client/virtualise.ffi.mjs
@@ -1,0 +1,82 @@
+import { Empty, NonEmpty } from '../../../gleam.mjs';
+import { element, namespaced, fragment, text, none } from '../../element.mjs';
+import { attribute } from '../../attribute.mjs';
+import { empty_list } from '../../internals/constants.mjs';
+
+const HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+
+export function virtualise(root) {
+  const vdom = virtualise_node(root);
+  if (vdom.children instanceof Empty) {
+    // at this point we know the element is empty - but we have to have at least
+    // an empty text node child in the root element to be able to mount
+    root.appendChild(document.createTextNode(''));
+    return none();
+  } else if (vdom.children instanceof NonEmpty && vdom.children.tail instanceof Empty) {
+    return vdom.children.head;
+  } else {
+    return fragment(vdom.children);
+  }
+}
+
+function virtualise_node(node) {
+  switch (node.nodeType) {
+    case Node.ELEMENT_NODE: {
+      const tag = node.localName;
+      const namespace = node.namespaceURI;
+
+      const attributes = virtualise_attributes(node);
+      const children = virtualise_child_nodes(node);
+
+      return !namespace || namespace === HTML_NAMESPACE
+        ? element(tag, attributes, children)
+        : namespaced(namespace, tag, attributes, children);
+    };
+
+    case Node.TEXT_NODE:
+      return text(node.textContent);
+
+    default:
+      return null;
+  }
+}
+
+function virtualise_child_nodes(node) {
+  let index = node.childNodes.length;
+
+  let children = empty_list;
+  const nodesToRemove = [];
+  while (index-- > 0) {
+    const child = virtualise_node(node.childNodes[index]);
+    if (child) {
+      children = new NonEmpty(child, children);
+    } else {
+      nodesToRemove.push(node.childNodes[index]);
+    }
+  }
+
+  // we have to remove all nodes we cannot virtualise to make sure the indices
+  // used in the patch line up.
+  for (const child of nodesToRemove) {
+    node.removeChild(child);
+  }
+
+  return children;
+}
+
+function virtualise_attributes(node) {
+  let index = node.attributes.length;
+
+  let attributes = empty_list;
+  while (index-- > 0) {
+    attributes = new NonEmpty(virtualise_attribute(node.attributes[index]), attributes);
+  }
+
+  return attributes;
+}
+
+function virtualise_attribute(attr) {
+  const name = attr.localName;
+  const value = attr.value;
+  return attribute(name, value);
+}

--- a/src/lustre/runtime/client/virtualise.ffi.mjs
+++ b/src/lustre/runtime/client/virtualise.ffi.mjs
@@ -7,8 +7,8 @@ const HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
 
 export function virtualise(root) {
   const vdom = virtualise_node(root);
-  if (vdom.children instanceof Empty) {
-    // at this point we know the element is empty - but we have to have at least
+  // at this point we know the element is empty - but we have to have at least
+  if (vdom === null || vdom.children instanceof Empty) {
     // an empty text node child in the root element to be able to mount
     root.appendChild(document.createTextNode(''));
     return none();
@@ -34,7 +34,13 @@ function virtualise_node(node) {
     };
 
     case Node.TEXT_NODE:
-      return text(node.textContent);
+      return text(node.data);
+
+    case Node.DOCUMENT_FRAGMENT_NODE:
+      return node.childNodes.length > 0
+        ? fragment(virtualise_child_nodes(node))
+        : null;
+
 
     default:
       return null;

--- a/src/lustre/runtime/client/virtualise.ffi.mjs
+++ b/src/lustre/runtime/client/virtualise.ffi.mjs
@@ -8,8 +8,8 @@ const HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
 export function virtualise(root) {
   const vdom = virtualise_node(root);
   // at this point we know the element is empty - but we have to have at least
+  // an empty text node child in the root element to be able to mount
   if (vdom === null || vdom.children instanceof Empty) {
-    // an empty text node child in the root element to be able to mount
     root.appendChild(document.createTextNode(''));
     return none();
   } else if (vdom.children instanceof NonEmpty && vdom.children.tail instanceof Empty) {
@@ -36,11 +36,10 @@ function virtualise_node(node) {
     case Node.TEXT_NODE:
       return text(node.data);
 
-    case Node.DOCUMENT_FRAGMENT_NODE:
+    case Node.DOCUMENT_FRAGMENT_NODE: // shadowRoot
       return node.childNodes.length > 0
         ? fragment(virtualise_child_nodes(node))
         : null;
-
 
     default:
       return null;

--- a/src/lustre/vdom/attribute.gleam
+++ b/src/lustre/vdom/attribute.gleam
@@ -142,8 +142,8 @@ pub fn to_string_tree(attributes: List(Attribute(msg))) -> #(StringTree, String)
 
 pub fn to_string_parts(attr: Attribute(msg)) -> Result(#(String, String), Nil) {
   case attr {
-    Attribute("", _) -> Error(Nil)
+    Attribute("", _) -> constants.error_nil
     Attribute(name, value) -> Ok(#(name, value))
-    _ -> Error(Nil)
+    _ -> constants.error_nil
   }
 }

--- a/src/lustre/vdom/diff.gleam
+++ b/src/lustre/vdom/diff.gleam
@@ -321,41 +321,27 @@ fn do_diff(
         }
 
         // The previous child no longer exists in the incoming tree *and* the new
-        // child is new for this render. That means we can do a straight `Replace`.
+        // child is new for this render. The new element can "steal" the previous
+        // one to continue diffing like normal by setting its key!
         Error(_), Error(_) -> {
-          let prev_count = advance(prev)
-          let changes = case prev_count > 1 {
-            False -> changes
-            True -> {
-              let from = node_index - moved_offset + 1
-              let remove = Remove(from:, count: prev_count - 1)
-
-              [remove, ..changes]
-            }
+          let prev_with_key = case prev {
+            Element(..) -> Element(..prev, key: next.key)
+            Fragment(..) -> Fragment(..prev, key: next.key)
+            Text(..) -> Text(..prev, key: next.key)
           }
 
-          let child =
-            Patch(
-              index: node_index,
-              removed: 0,
-              changes: [Replace(next)],
-              children: constants.empty_list,
-            )
-
-          let events = events.add_child(events, mapper, node_index, next)
-
           do_diff(
-            old: old_remaining,
+            old: [prev_with_key, ..old_remaining],
             old_keyed:,
-            new: new_remaining,
+            new:,
             new_keyed:,
             moved:,
-            moved_offset: moved_offset - prev_count + 1,
+            moved_offset:,
             removed:,
-            node_index: node_index + 1,
+            node_index:,
             patch_index:,
             changes:,
-            children: [child, ..children],
+            children:,
             events:,
             mapper:,
           )

--- a/test-apps/keyed-diffs/src/app.ffi.mjs
+++ b/test-apps/keyed-diffs/src/app.ffi.mjs
@@ -1,1 +1,0 @@
-export const random_id = () => window.crypto.randomUUID();

--- a/test/tests/diff_test.gleam
+++ b/test/tests/diff_test.gleam
@@ -645,6 +645,33 @@ pub fn mixed_text_and_element_changes_test() {
   |> should.equal(diff)
 }
 
+pub fn non_keyed_upgrade_test() {
+  use <- lustre_test.test_filter("non_keyed_upgrade_test")
+
+  let prev =
+    html.div([], [
+      html.div([attribute.class("old")], [html.text("one")]),
+      html.div([attribute.class("old")], [html.text("two")]),
+    ])
+
+  let next =
+    keyed.div([], [
+      #("1", html.div([attribute.class("new")], [html.text("one")])),
+      #("2", html.div([attribute.class("new")], [html.text("two")])),
+    ])
+
+  let diff =
+    Patch(0, 0, [], [
+      Patch(0, 0, [], [
+        Patch(1, 0, [Update([attribute.class("new")], [])], []),
+        Patch(0, 0, [Update([attribute.class("new")], [])], []),
+      ]),
+    ])
+
+  diff.diff(prev, next, 0).patch
+  |> should.equal(diff)
+}
+
 // KEYED DIFFS WITH FRAGMENTS --------------------------------------------------
 
 pub fn keyed_move_fragment_with_replace_with_different_count_test() {


### PR DESCRIPTION
I changed the diff to diff keyed elements like normal, if an old/new pair would have been a replace previously. This means nodes can be gracefully "upgraded" from non-keyed to keyed nodes, making virtualisation more useful. The only reason we bail now is when using fragments.

All boolean properties are attributes now, which means we can support them during SSR as well. I tested them all and added hooks that sync them to a property when the browser does not automatically do that already.

`autofocus` and `autoplay` are special-cased to trigger their associated action when changing their value from `False` to `True`.