### PR TITLE
Replace `nil_error` with  `replace_error(Nil)` in docs

### DIFF
--- a/pages/guide/06-full-stack-applications.md
+++ b/pages/guide/06-full-stack-applications.md
@@ -165,7 +165,7 @@ fn view_grocery_list(model: Model) -> Element(Msg) {
 fn view_grocery_item(name: String, quantity: Int) -> Element(Msg) {
   let handle_input = fn(e) {
     event.value(e)
-    |> result.nil_error
+    |> result.replace_error(Nil)
     |> result.then(int.parse)
     |> result.map(UserUpdatedQuantity(name, _))
     |> result.replace_error([])


### PR DESCRIPTION
`nil_error` no longer exists in gleam/result, so I've replaced it with `replace_error(Nil)`