### PR TITLE
Add many more attributes to `lustre/attribute`.

### DIFF
--- a/examples/03-effects/04-local-storage/README.md
+++ b/examples/03-effects/04-local-storage/README.md
@@ -1,0 +1,1 @@
+# 03-effects/04-local-storage

--- a/examples/03-effects/04-local-storage/gleam.toml
+++ b/examples/03-effects/04-local-storage/gleam.toml
@@ -1,0 +1,9 @@
+name = "app"
+version = "1.0.0"
+dev-dependencies = { lustre_dev_tools = ">= 1.6.5 and < 2.0.0" }
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+lustre = { path = "../../../" }
+gleam_json = ">= 2.3.0 and < 3.0.0"
+formal = ">= 2.2.0 and < 3.0.0"

--- a/examples/03-effects/04-local-storage/index.html
+++ b/examples/03-effects/04-local-storage/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <title>03-effects/04-local-storage</title>
+
+        <!-- Uncomment this if you add the TailwindCSS integration -->
+        <link rel="stylesheet" href="/priv/static/app.css" />
+        <script type="module" src="/priv/static/app.mjs"></script>
+    </head>
+
+    <body>
+        <div id="app"></div>
+    </body>
+</html>

--- a/examples/03-effects/04-local-storage/src/app.ffi.mjs
+++ b/examples/03-effects/04-local-storage/src/app.ffi.mjs
@@ -1,0 +1,24 @@
+import { Ok, Error } from "./gleam.mjs";
+
+// It's often convenient to write FFI functions in a way that constructs or wraps
+// return values in existing, known Gleam values. In Gleam we annotated this FFI
+// function as returning a `Result` so we import the constructors and use them
+// directly.
+export function get_localstorage(key) {
+  const json = window.localStorage.getItem(key);
+
+  // Gleam's `Nil` value is represented as `undefined` in JavaScript.
+  if (json === null) return new Error(undefined);
+
+  try {
+    return new Ok(JSON.parse(json));
+  } catch {
+    return new Error(undefined);
+  }
+}
+
+// Not all FFI needs to return something, sometimes a side effect is just a side
+// effect!
+export function set_localstorage(key, json) {
+  window.localStorage.setItem(key, json);
+}

--- a/examples/03-effects/04-local-storage/src/app.gleam
+++ b/examples/03-effects/04-local-storage/src/app.gleam
@@ -1,0 +1,217 @@
+// IMPORTS ---------------------------------------------------------------------
+
+import formal/form
+import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type Decoder}
+import gleam/function
+import gleam/int
+import gleam/json.{type Json}
+import gleam/list
+import gleam/result
+import lustre
+import lustre/attribute
+import lustre/effect.{type Effect}
+import lustre/element.{type Element}
+import lustre/element/html
+import lustre/element/keyed
+import lustre/event
+
+// MAIN ------------------------------------------------------------------------
+
+pub fn main() {
+  let app = lustre.application(init, update, view)
+  let assert Ok(_) = lustre.start(app, "#app", Nil)
+
+  Nil
+}
+
+// MODEL -----------------------------------------------------------------------
+
+type Model {
+  Model(todos: List(Todo), next_id: Int)
+}
+
+type Todo {
+  Todo(id: Int, title: String, completed: Bool)
+}
+
+fn init(_) -> #(Model, Effect(Msg)) {
+  let todos = []
+  let next_id = 0
+
+  // When our program first loads, we'll immediately dispatch an effect to read
+  // any existing todos from local storage. Because this effect is synchronous,
+  // it will run and return before the app renders.
+  #(Model(todos:, next_id:), get_todos())
+}
+
+// UPDATE ----------------------------------------------------------------------
+
+type Msg {
+  LocalStorageReturnedTodos(Result(List(Todo), Nil))
+  UserToggledTodo(id: Int, completed: Bool)
+  UserCreatedTodo(Result(String, Nil))
+}
+
+fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
+  case msg {
+    LocalStorageReturnedTodos(Error(_)) -> #(model, effect.none())
+    LocalStorageReturnedTodos(Ok(todos)) -> {
+      let next_id =
+        list.fold(todos, model.next_id, fn(max, item) {
+          case item.id >= max {
+            True -> item.id + 1
+            False -> max
+          }
+        })
+
+      #(Model(todos:, next_id:), effect.none())
+    }
+
+    UserToggledTodo(id:, completed:) -> {
+      let todos =
+        list.map(model.todos, fn(item) {
+          case item.id == id {
+            True -> Todo(..item, completed:)
+            False -> item
+          }
+        })
+
+      #(Model(..model, todos:), set_todos(todos))
+    }
+
+    UserCreatedTodo(Error(_)) -> #(model, effect.none())
+    UserCreatedTodo(Ok(title)) -> {
+      let todos = list.append(model.todos, [Todo(model.next_id, title, False)])
+      let next_id = model.next_id + 1
+
+      #(Model(todos:, next_id:), set_todos(todos))
+    }
+  }
+}
+
+fn get_todos() -> Effect(Msg) {
+  use dispatch <- effect.from
+  let result =
+    // Once we're inside a custom effect, we can call effectful functions like
+    // `get_localstorage` directly. We've stepped "outside" of Lustre and don't
+    // have to worry about pure functions anymore.
+    result.try(get_localstorage("todos"), fn(dyn) {
+      case decode.run(dyn, decode.list(todo_decoder())) {
+        Ok(todos) -> Ok(todos)
+        Error(_) -> Error(Nil)
+      }
+    })
+
+  dispatch(LocalStorageReturnedTodos(result))
+}
+
+fn todo_decoder() -> Decoder(Todo) {
+  use id <- decode.field("id", decode.int)
+  use title <- decode.field("title", decode.string)
+  use completed <- decode.field("completed", decode.bool)
+
+  decode.success(Todo(id:, title:, completed:))
+}
+
+@external(javascript, "./app.ffi.mjs", "get_localstorage")
+fn get_localstorage(_key: String) -> Result(Dynamic, Nil) {
+  Error(Nil)
+}
+
+// Not all effects will dispatch messages. Just like element's that dont dispatch
+// events, it's good practice to annotate these effects using a generic `msg`
+// type so they can be used in any context.
+fn set_todos(todos: List(Todo)) -> Effect(msg) {
+  use _ <- effect.from
+  let json = json.array(todos, encode_todo)
+
+  set_localstorage("todos", json.to_string(json))
+}
+
+fn encode_todo(item: Todo) -> Json {
+  json.object([
+    #("id", json.int(item.id)),
+    #("title", json.string(item.title)),
+    #("completed", json.bool(item.completed)),
+  ])
+}
+
+@external(javascript, "./app.ffi.mjs", "set_localstorage")
+fn set_localstorage(_key: String, _value: String) -> Nil {
+  Nil
+}
+
+// VIEW ------------------------------------------------------------------------
+
+fn view(model: Model) -> Element(Msg) {
+  html.div([attribute.class("p-32 mx-auto w-full max-w-2xl space-y-8")], [
+    html.h1([attribute.class("font-semibold text-2xl")], [html.text("Todo:")]),
+    keyed.ul([attribute.class("flex flex-col gap-2")], {
+      list.map(model.todos, fn(item) {
+        let key = int.to_string(item.id)
+        let html =
+          html.li([], [
+            view_todo(item:, on_complete: UserToggledTodo(item.id, _)),
+          ])
+
+        #(key, html)
+      })
+    }),
+    html.hr([]),
+    view_input(on_submit: UserCreatedTodo),
+  ])
+}
+
+fn view_todo(
+  item item: Todo,
+  on_complete handle_complete: fn(Bool) -> msg,
+) -> Element(msg) {
+  html.label([attribute.class("flex gap-2 items-baseline")], [
+    html.p(
+      [
+        attribute.class("flex-1"),
+        attribute.classes([#("line-through text-slate-400", item.completed)]),
+      ],
+      [html.text(item.title)],
+    ),
+    html.input([
+      attribute.type_("checkbox"),
+      attribute.checked(item.completed),
+      event.on_check(handle_complete),
+    ]),
+  ])
+}
+
+fn view_input(
+  on_submit handle_submit: fn(Result(String, Nil)) -> msg,
+) -> Element(msg) {
+  let on_submit =
+    event.on_submit(fn(fields) {
+      form.decoding(into: function.identity)
+      |> form.with_values(fields)
+      |> form.field("title", form.string |> form.and(form.must_not_be_empty))
+      |> form.finish
+      |> result.replace_error(Nil)
+      |> handle_submit
+    })
+
+  html.form([attribute.id("new-todo"), on_submit], [
+    html.label([attribute.for("title"), attribute.class("block text-sm mb-2")], [
+      html.text("What do you need to do?"),
+    ]),
+    html.div([attribute.class("flex gap-2 items-center")], [
+      html.input([
+        attribute.class("flex-1 px-2 py-1 border border-slate-300 rounded"),
+        attribute.class("focus:outline-none focus:border-blue-500"),
+        attribute.id("title"),
+        attribute.name("title"),
+        attribute.required(True),
+      ]),
+      html.button(
+        [attribute.class("px-4 py-1 bg-blue-500 text-white rounded")],
+        [html.text("Add")],
+      ),
+    ]),
+  ])
+}

--- a/examples/03-effects/04-local-storage/tailwind.config.js
+++ b/examples/03-effects/04-local-storage/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{gleam,mjs}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/src/lustre.gleam
+++ b/src/lustre.gleam
@@ -275,13 +275,13 @@ pub fn application(
 /// other HTML element. This dictionary of decoders allows you to specify how to
 /// decode those attributes into messages your component's update loop can handle.
 ///
-/// **Note**: Lustre components are conceptually a lot "heavier" than components
-/// in frameworks like React. They should be used for more complex UI widgets
-/// like a combobox with complex keyboard interactions rather than simple things
-/// like buttons or text inputs. Where possible try to think about how to build
-/// your UI with simple view functions (functions that return [Elements](./lustre/element.html#Element))
-/// and only reach for components when you really need to encapsulate that update
-/// loop.
+/// > **Note**: Lustre components are conceptually a lot "heavier" than components
+/// > in frameworks like React. They should be used for more complex UI widgets
+/// > like a combobox with complex keyboard interactions rather than simple things
+/// > like buttons or text inputs. Where possible try to think about how to build
+/// > your UI with simple view functions (functions that return [Elements](./lustre/element.html#Element))
+/// > and only reach for components when you really need to encapsulate that update
+/// > loop.
 ///
 pub fn component(
   init: fn(flags) -> #(model, Effect(msg)),
@@ -385,15 +385,15 @@ fn do_start_actor(
 /// with the name `my-component`, you'd use it in HTML by writing `<my-component>`
 /// or in Lustre by rendering `element("my-component", [], [])`.
 ///
-/// **Note**: There are [some rules](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names)
-/// for what names are valid for a Custom Element. The most important one is that
-/// the name *must* contain a hypen so that it can be distinguished from standard
-/// HTML elements.
+/// > **Note**: There are [some rules](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names)
+/// > for what names are valid for a Custom Element. The most important one is that
+/// > the name *must* contain a hypen so that it can be distinguished from standard
+/// > HTML elements.
 ///
-/// **Note**: This function is only meaningful when running in the browser and will
-/// produce a `NotABrowser` error if called anywhere else. For server contexts,
-/// you can render a Lustre server component using [`start_server_component`](#start_server_component)
-/// or [`start_actor`](#start_actor) instead.
+/// > **Note**: This function is only meaningful when running in the browser and will
+/// > produce a `NotABrowser` error if called anywhere else. For server contexts,
+/// > you can render a Lustre server component using [`start_server_component`](#start_server_component)
+/// > or [`start_actor`](#start_actor) instead.
 ///
 @external(javascript, "./lustre/runtime/client/component.ffi.mjs", "make_component")
 pub fn register(_app: App(Nil, model, msg), _name: String) -> Result(Nil, Error) {
@@ -407,11 +407,11 @@ pub fn register(_app: App(Nil, model, msg), _name: String) -> Result(Nil, Error)
 /// example by attaching event listeners to the document to dispatch messages
 /// after the app has been started.
 ///
-/// **Note**: This function is only meaningful when running on the JavaScript
-/// target as a `Runtime` can only be constructed on that target. If you are
-/// running a server component on the Erlang target, you should use Gleam's usual
-/// api for sending messages to actors and the `Subject` returned from
-/// [`start_actor`](#start_actor).
+/// > **Note**: This function is only meaningful when running on the JavaScript
+/// > target as a `Runtime` can only be constructed on that target. If you are
+/// > running a server component on the Erlang target, you should use Gleam's usual
+/// > api for sending messages to actors and the `Subject` returned from
+/// > [`start_actor`](#start_actor).
 ///
 @external(erlang, "gleam@erlang@process", "send")
 @external(javascript, "./lustre/runtime/client/runtime.ffi.mjs", "send")

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -41,6 +41,13 @@ pub fn property(name: String, value: Json) -> Attribute(msg) {
   vattr.property(name, value)
 }
 
+fn boolean_attribute(name: String, value: Bool) -> Attribute(msg) {
+  case value {
+    True -> attribute(name, "")
+    False -> property(name, json.bool(False))
+  }
+}
+
 ///
 pub fn on(name: String, handler: Decoder(msg)) -> Attribute(msg) {
   vattr.event(
@@ -121,12 +128,17 @@ pub fn classes(names: List(#(String, Bool))) -> Attribute(msg) {
   })
 }
 
-///
-///
 /// Add a `data-*` attribute to an HTML element. The key will be prefixed by `data-`.
 ///
 pub fn data(key: String, value: String) -> Attribute(msg) {
   attribute("data-" <> key, value)
+}
+
+/// Add an `aria-*` attribute to an HTML element. The key will be prefixed by
+/// `aria-`.
+///
+pub fn aria(name: String, value: String) -> Attribute(msg) {
+  attribute("aria-" <> name, value)
 }
 
 ///
@@ -456,11 +468,408 @@ pub fn lang(name: String) -> Attribute(msg) {
   attribute("lang", name)
 }
 
-// HELPERS ---------------------------------------------------------------------
+// ARIA ------------------------------------------------------------------------
 
-fn boolean_attribute(name: String, value: Bool) -> Attribute(msg) {
-  case value {
-    True -> attribute(name, "")
-    False -> property(name, json.bool(False))
-  }
+/// The aria-activedescendant attribute identifies the currently active element
+/// when focus is on a composite widget, combobox, textbox, group, or application.
+///
+pub fn aria_activedescendant(id: String) -> Attribute(msg) {
+  aria("activedescendant", id)
+}
+
+/// In ARIA live regions, the global aria-atomic attribute indicates whether
+/// assistive technologies such as a screen reader will present all, or only parts
+/// of, the changed region based on the change notifications defined by the
+/// aria-relevant attribute.
+///
+pub fn aria_atomic(value: Bool) -> Attribute(msg) {
+  aria("atomic", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The aria-autocomplete attribute indicates whether inputting text could trigger
+/// display of one or more predictions of the user's intended value for a combobox,
+/// searchbox, or textbox and specifies how predictions will be presented if they
+/// are made.
+///
+pub fn aria_autocomplete(value: String) -> Attribute(msg) {
+  aria("autocomplete", value)
+}
+
+/// The global aria-braillelabel property defines a string value that labels the
+/// current element, which is intended to be converted into Braille.
+///
+pub fn aria_braillelabel(value: String) -> Attribute(msg) {
+  aria("braillelabel", value)
+}
+
+/// The global aria-brailleroledescription attribute defines a human-readable,
+/// author-localized abbreviated description for the role of an element intended
+/// to be converted into Braille.
+///
+pub fn aria_brailleroledescription(value: String) -> Attribute(msg) {
+  aria("brailleroledescription", value)
+}
+
+/// Used in ARIA live regions, the global aria-busy state indicates an element is
+/// being modified and that assistive technologies may want to wait until the
+/// changes are complete before informing the user about the update.
+///
+pub fn aria_busy(value: Bool) -> Attribute(msg) {
+  aria("busy", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The aria-checked attribute indicates the current "checked" state of checkboxes,
+/// radio buttons, and other widgets.
+///
+pub fn aria_checked(value: String) -> Attribute(msg) {
+  aria("checked", value)
+}
+
+/// The aria-colcount attribute defines the total number of columns in a table,
+/// grid, or treegrid when not all columns are present in the DOM.
+///
+pub fn aria_colcount(value: Int) -> Attribute(msg) {
+  aria("colcount", int.to_string(value))
+}
+
+/// The aria-colindex attribute defines an element's column index or position with
+/// respect to the total number of columns within a table, grid, or treegrid.
+///
+pub fn aria_colindex(value: Int) -> Attribute(msg) {
+  aria("colindex", int.to_string(value))
+}
+
+/// The aria-colindextext attribute defines a human-readable text alternative of
+/// the numeric aria-colindex.
+///
+pub fn aria_colindextext(value: String) -> Attribute(msg) {
+  aria("colindextext", value)
+}
+
+/// The aria-colspan attribute defines the number of columns spanned by a cell
+/// or gridcell within a table, grid, or treegrid.
+///
+pub fn aria_colspan(value: Int) -> Attribute(msg) {
+  aria("colspan", int.to_string(value))
+}
+
+/// The global aria-controls property identifies the element (or elements) whose
+/// contents or presence are controlled by the element on which this attribute is
+/// set.
+///
+pub fn aria_controls(value: String) -> Attribute(msg) {
+  aria("controls", value)
+}
+
+/// A non-null aria-current state on an element indicates that this element represents
+/// the current item within a container or set of related elements.
+///
+pub fn aria_current(value: String) -> Attribute(msg) {
+  aria("current", value)
+}
+
+/// The global aria-describedby attribute identifies the element (or elements)
+/// that describes the element on which the attribute is set.
+///
+pub fn aria_describedby(value: String) -> Attribute(msg) {
+  aria("describedby", value)
+}
+
+/// The global aria-description attribute defines a string value that describes
+/// or annotates the current element.
+///
+pub fn aria_description(value: String) -> Attribute(msg) {
+  aria("description", value)
+}
+
+/// The global aria-details attribute identifies the element (or elements) that
+/// provide additional information related to the object.
+///
+pub fn aria_details(value: String) -> Attribute(msg) {
+  aria("details", value)
+}
+
+/// The aria-disabled state indicates that the element is perceivable but disabled,
+/// so it is not editable or otherwise operable.
+///
+pub fn aria_disabled(value: Bool) -> Attribute(msg) {
+  aria("disabled", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The aria-errormessage attribute on an object identifies the element that
+/// provides an error message for that object.
+///
+pub fn aria_errormessage(value: String) -> Attribute(msg) {
+  aria("errormessage", value)
+}
+
+/// The aria-expanded attribute is set on an element to indicate if a control is
+/// expanded or collapsed, and whether or not the controlled elements are displayed
+/// or hidden.
+///
+pub fn aria_expanded(value: Bool) -> Attribute(msg) {
+  aria("expanded", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The global aria-flowto attribute identifies the next element (or elements) in
+/// an alternate reading order of content. This allows assistive technology to
+/// override the general default of reading in document source order at the user's
+/// discretion.
+///
+pub fn aria_flowto(value: String) -> Attribute(msg) {
+  aria("flowto", value)
+}
+
+/// The aria-haspopup attribute indicates the availability and type of interactive
+/// popup element that can be triggered by the element on which the attribute is
+/// set.
+///
+pub fn aria_haspopup(value: String) -> Attribute(msg) {
+  aria("haspopup", value)
+}
+
+/// The aria-hidden state indicates whether the element is exposed to an accessibility
+/// API.
+///
+pub fn aria_hidden(value: Bool) -> Attribute(msg) {
+  aria("hidden", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The aria-invalid state indicates the entered value does not conform to the
+/// format expected by the application.
+///
+pub fn aria_invalid(value: String) -> Attribute(msg) {
+  aria("invalid", value)
+}
+
+/// The global aria-keyshortcuts attribute indicates keyboard shortcuts that an
+/// author has implemented to activate or give focus to an element.
+///
+pub fn aria_keyshortcuts(value: String) -> Attribute(msg) {
+  aria("keyshortcuts", value)
+}
+
+/// The aria-label attribute defines a string value that can be used to name an
+/// element, as long as the element's role does not prohibit naming.
+///
+pub fn aria_label(value: String) -> Attribute(msg) {
+  aria("label", value)
+}
+
+/// The aria-labelledby attribute identifies the element (or elements) that labels
+/// the element it is applied to.
+///
+pub fn aria_labelledby(value: String) -> Attribute(msg) {
+  aria("labelledby", value)
+}
+
+/// The aria-level attribute defines the hierarchical level of an element within
+/// a structure.
+///
+pub fn aria_level(value: Int) -> Attribute(msg) {
+  aria("level", int.to_string(value))
+}
+
+/// The global aria-live attribute indicates that an element will be updated, and
+/// describes the types of updates the user agents, assistive technologies, and
+/// user can expect from the live region.
+///
+pub fn aria_live(value: String) -> Attribute(msg) {
+  aria("live", value)
+}
+
+/// The aria-modal attribute indicates whether an element is modal when displayed.
+///
+pub fn aria_modal(value: Bool) -> Attribute(msg) {
+  aria("modal", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The aria-multiline attribute indicates whether a textbox accepts multiple
+/// lines of input or only a single line.
+///
+pub fn aria_multiline(value: Bool) -> Attribute(msg) {
+  aria("multiline", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The aria-multiselectable attribute indicates that the user may select more
+/// than one item from the current selectable descendants.
+///
+pub fn aria_multiselectable(value: Bool) -> Attribute(msg) {
+  aria("multiselectable", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The aria-orientation attribute indicates whether the element's orientation is
+/// horizontal, vertical, or unknown/ambiguous.
+///
+pub fn aria_orientation(value: String) -> Attribute(msg) {
+  aria("orientation", value)
+}
+
+/// The aria-owns attribute identifies an element (or elements) in order to define
+/// a visual, functional, or contextual relationship between a parent and its
+/// child elements when the DOM hierarchy cannot be used to represent the relationship.
+///
+pub fn aria_owns(value: String) -> Attribute(msg) {
+  aria("owns", value)
+}
+
+/// The aria-placeholder attribute defines a short hint (a word or short phrase)
+/// intended to help the user with data entry when a form control has no value.
+/// The hint can be a sample value or a brief description of the expected format.
+///
+pub fn aria_placeholder(value: String) -> Attribute(msg) {
+  aria("placeholder", value)
+}
+
+/// The aria-posinset attribute defines an element's number or position in the
+/// current set of listitems or treeitems when not all items are present in the
+/// DOM.
+///
+pub fn aria_posinset(value: Int) -> Attribute(msg) {
+  aria("posinset", int.to_string(value))
+}
+
+/// The aria-pressed attribute indicates the current "pressed" state of a toggle
+/// button.
+///
+pub fn aria_pressed(value: String) -> Attribute(msg) {
+  aria("pressed", value)
+}
+
+/// The aria-readonly attribute indicates that the element is not editable, but is
+/// otherwise operable.
+///
+pub fn aria_readonly(value: Bool) -> Attribute(msg) {
+  aria("readonly", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// Used in ARIA live regions, the global aria-relevant attribute indicates what
+/// notifications the user agent will trigger when the accessibility tree within
+/// a live region is modified.
+///
+pub fn aria_relevant(value: String) -> Attribute(msg) {
+  aria("relevant", value)
+}
+
+/// The aria-required attribute indicates that user input is required on the element
+/// before a form may be submitted.
+///
+pub fn aria_required(value: Bool) -> Attribute(msg) {
+  aria("required", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The aria-roledescription attribute defines a human-readable, author-localised
+/// description for the role of an element.
+///
+pub fn aria_roledescription(value: String) -> Attribute(msg) {
+  aria("roledescription", value)
+}
+
+/// The aria-rowcount attribute defines the total number of rows in a table,
+/// grid, or treegrid.
+///
+pub fn aria_rowcount(value: Int) -> Attribute(msg) {
+  aria("rowcount", int.to_string(value))
+}
+
+/// The aria-rowindex attribute defines an element's position with respect to the
+/// total number of rows within a table, grid, or treegrid.
+///
+pub fn aria_rowindex(value: Int) -> Attribute(msg) {
+  aria("rowindex", int.to_string(value))
+}
+
+/// The aria-rowindextext attribute defines a human-readable text alternative of
+/// aria-rowindex.
+///
+pub fn aria_rowindextext(value: String) -> Attribute(msg) {
+  aria("rowindextext", value)
+}
+
+/// The aria-rowspan attribute defines the number of rows spanned by a cell or
+/// gridcell within a table, grid, or treegrid.
+///
+pub fn aria_rowspan(value: Int) -> Attribute(msg) {
+  aria("rowspan", int.to_string(value))
+}
+
+/// The aria-selected attribute indicates the current "selected" state of various
+/// widgets.
+///
+pub fn aria_selected(value: Bool) -> Attribute(msg) {
+  aria("selected", case value {
+    True -> "true"
+    False -> "false"
+  })
+}
+
+/// The aria-setsize attribute defines the number of items in the current set of
+/// listitems or treeitems when not all items in the set are present in the DOM.
+///
+pub fn aria_setsize(value: Int) -> Attribute(msg) {
+  aria("setsize", int.to_string(value))
+}
+
+/// The aria-sort attribute indicates if items in a table or grid are sorted in
+/// ascending or descending order.
+///
+pub fn aria_sort(value: String) -> Attribute(msg) {
+  aria("sort", value)
+}
+
+/// The aria-valuemax attribute defines the maximum allowed value for a range
+/// widget.
+///
+pub fn aria_valuemax(value: String) -> Attribute(msg) {
+  aria("valuemax", value)
+}
+
+/// The aria-valuemin attribute defines the minimum allowed value for a range
+/// widget.
+///
+pub fn aria_valuemin(value: String) -> Attribute(msg) {
+  aria("valuemin", value)
+}
+
+/// The aria-valuenow attribute defines the current value for a range widget.
+///
+pub fn aria_valuenow(value: String) -> Attribute(msg) {
+  aria("valuenow", value)
+}
+
+/// The aria-valuetext attribute defines the human-readable text alternative of
+/// aria-valuenow for a range widget.
+///
+pub fn aria_valuetext(value: String) -> Attribute(msg) {
+  aria("valuetext", value)
 }

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -1,12 +1,9 @@
 // IMPORTS ---------------------------------------------------------------------
 
-import gleam/dynamic/decode.{type Decoder}
 import gleam/int
 import gleam/json.{type Json}
-import gleam/list
 import gleam/string
-import lustre/internals/constants
-import lustre/vdom/vattr.{Attribute, Event, Property}
+import lustre/vdom/vattr.{Attribute}
 
 // TYPES -----------------------------------------------------------------------
 
@@ -21,9 +18,9 @@ pub type Attribute(msg) =
 /// Create an HTML attribute. This is like saying `element.setAttribute("class", "wibble")`
 /// in JavaScript. Attributes will be rendered when calling [`element.to_string`](./element.html#to_string).
 ///
-/// **Note**: there is a subtle difference between attributes and properties. You
-/// can read more about the implications of this
-/// [here](https://github.com/lustre-labs/lustre/blob/main/pages/hints/attributes-vs-properties.md).
+/// > **Note**: there is a subtle difference between attributes and properties. You
+/// > can read more about the implications of this
+/// > [here](https://github.com/lustre-labs/lustre/blob/main/pages/hints/attributes-vs-properties.md).
 ///
 pub fn attribute(name: String, value: String) -> Attribute(msg) {
   vattr.attribute(name, value)
@@ -40,34 +37,12 @@ fn boolean_attribute(name: String, value: Bool) -> Attribute(msg) {
 /// JavaScript. Properties will be **not** be rendered when calling
 /// [`element.to_string`](./element.html#to_string).
 ///
-/// **Note**: there is a subtle difference between attributes and properties. You
-/// can read more about the implications of this
-/// [here](https://github.com/lustre-labs/lustre/blob/main/pages/hints/attributes-vs-properties.md).
+/// > **Note**: there is a subtle difference between attributes and properties. You
+/// > can read more about the implications of this
+/// > [here](https://github.com/lustre-labs/lustre/blob/main/pages/hints/attributes-vs-properties.md).
 ///
 pub fn property(name: String, value: Json) -> Attribute(msg) {
   vattr.property(name, value)
-}
-
-///
-///
-pub fn on(name: String, handler: Decoder(msg)) -> Attribute(msg) {
-  vattr.event(
-    name:,
-    handler:,
-    include: constants.empty_list,
-    prevent_default: False,
-    stop_propagation: False,
-    immediate: is_immediate_event(name),
-    limit: vattr.NoLimit(kind: 0),
-  )
-}
-
-fn is_immediate_event(name: String) -> Bool {
-  case name {
-    "input" | "change" | "focus" | "focusin" | "focusout" | "blur" | "select" ->
-      True
-    _ -> False
-  }
 }
 
 /// Create an empty attribute. This is not added to the DOM and not rendered when
@@ -140,15 +115,22 @@ pub fn autocorrect(enabled: Bool) -> Attribute(msg) {
 }
 
 /// For server-rendered HTML, this attribute controls whether an element should
-/// be focused when the page first loads. Lustre's runtime augments the native
-/// behaviour of this attribute: when enabled, the element will automatically be
-/// focused even if it already exists in the DOM.
+/// be focused when the page first loads.
+///
+/// > **Note**: Lustre's runtime augments that native behaviour of this attribute.
+/// > Whenever it is toggled true, the element will be automatically focused even
+/// > if it already exists in the DOM.
 ///
 pub fn autofocus(should_autofocus: Bool) -> Attribute(msg) {
   boolean_attribute("autofocus", should_autofocus)
 }
 
+/// A class is a non-unique identifier for an element primarily used for styling
+/// purposes. You can provide multiple classes as a space-separated list and any
+/// style rules that apply to any of the classes will be applied to the element.
 ///
+/// To conditionally toggle classes on and off, you can use the [`classes`](#classes)
+/// function instead.
 ///
 /// > **Note**: unlike most attributes, multiple `class` attributes are merged
 /// > with any existing other classes on an element. Classes added _later_ in the
@@ -158,7 +140,10 @@ pub fn class(name: String) -> Attribute(msg) {
   attribute("class", name)
 }
 
-///
+/// A class is a non-unique identifier for an element primarily used for styling
+/// purposes. You can provide multiple classes as a space-separated list and any
+/// style rules that apply to any of the classes will be applied to the element.
+/// This function allows you to conditionally toggle classes on and off.
 ///
 /// > **Note**: unlike most attributes, multiple `class` attributes are merged
 /// > with any existing other classes on an element. Classes added _later_ in the
@@ -193,7 +178,10 @@ pub fn contenteditable(is_editable: String) -> Attribute(msg) {
   attribute("contenteditable", is_editable)
 }
 
-/// Add a `data-*` attribute to an HTML element. The key will be prefixed by `data-`.
+/// Add a `data-*` attribute to an HTML element. The key will be prefixed by
+/// `"data-"`, and accessible from JavaScript or in Gleam decoders under the
+/// path `element.dataset.key` where `key` is the key you provide to this
+/// function.
 ///
 pub fn data(key: String, value: String) -> Attribute(msg) {
   attribute("data-" <> key, value)
@@ -259,7 +247,10 @@ pub fn hidden(is_hidden: Bool) -> Attribute(msg) {
   boolean_attribute("hidden", is_hidden)
 }
 
-///
+/// The `"id"` attribute is used to uniquely identify a single element within a
+/// document. It can be used to reference the element in CSS with the selector
+/// `#id`, in JavaScript with `document.getElementById("id")`, or by anchors on
+/// the same page with the URL `"#id"`.
 ///
 pub fn id(value: String) -> Attribute(msg) {
   attribute("id", value)
@@ -460,7 +451,23 @@ pub fn title(text: String) -> Attribute(msg) {
   attribute("title", text)
 }
 
-/// Controls whether an element's content should be translated.
+/// Controls whether an element's content may be translated by the user agent
+/// when the page is localised. This includes both the element's text content
+/// and some of its attributes:
+///
+/// | Attribute   | Element(s)                                 |
+/// |-------------|--------------------------------------------|
+/// | abbr        | th                                         |
+/// | alt         | area, img, input                           |
+/// | content     | meta                                       |
+/// | download    | a, area                                    |
+/// | label       | optgroup, option, track                    |
+/// | lang        | *                                          |
+/// | placeholder | input, textarea                            |
+/// | srcdoc      | iframe                                     |
+/// | title       | *                                          |
+/// | style       | *                                          |
+/// | value       | input (with type="button" or type="reset") |
 ///
 pub fn translate(should_translate: Bool) -> Attribute(msg) {
   attribute("translate", case should_translate {
@@ -478,7 +485,790 @@ pub fn writingsuggestions(enabled: Bool) -> Attribute(msg) {
   })
 }
 
-// ARIA ------------------------------------------------------------------------
+// ANCHOR AND LINK ATTRIBUTES --------------------------------------------------
+
+/// Specifies the URL of a linked resource. This attribute can be used on various
+/// elements to create hyperlinks or to load resources.
+///
+pub fn href(url: String) -> Attribute(msg) {
+  attribute("href", url)
+}
+
+/// Specifies where to display the linked resource or where to open the link.
+/// The following values are accepted:
+///
+/// | Value     | Description                                             |
+/// |-----------|---------------------------------------------------------|
+/// | "_self"   | Open in the same frame/window (default)                 |
+/// | "_blank"  | Open in a new window or tab                             |
+/// | "_parent" | Open in the parent frame                                |
+/// | "_top"    | Open in the full body of the window                     |
+/// | framename | Open in a named frame                                   |
+///
+/// > **Note**: consider against using `"_blank"` for links to external sites as it
+/// > removes user control over their browsing experience.
+///
+pub fn target(value: String) -> Attribute(msg) {
+  attribute("target", value)
+}
+
+/// Indicates that the linked resource should be downloaded rather than displayed.
+/// When provided with a value, it suggests a filename for the downloaded file.
+///
+pub fn download(filename: String) -> Attribute(msg) {
+  attribute("download", filename)
+}
+
+/// Provides a space-separated list of URLs that will be notified if the user
+/// follows the hyperlink. These URLs will receive POST requests with bodies
+/// of type `ping/1.0`.
+///
+pub fn ping(urls: List(String)) -> Attribute(msg) {
+  attribute("ping", string.join(urls, " "))
+}
+
+/// Specifies the relationship between the current document and the linked resource.
+/// Multiple relationship values can be provided as a space-separated list.
+///
+pub fn rel(value: String) -> Attribute(msg) {
+  attribute("rel", value)
+}
+
+/// Specifies the language of the linked resource. The value must be a valid
+/// [BCP 47 language tag](https://tools.ietf.org/html/bcp47).
+///
+pub fn hreflang(language: String) -> Attribute(msg) {
+  attribute("hreflang", language)
+}
+
+/// Specifies the referrer policy for fetches initiated by the element. The
+/// following values are accepted:
+///
+/// | Value                              | Description                                           |
+/// |-----------------------------------|--------------------------------------------------------|
+/// | "no-referrer"                     | No Referer header is sent                              |
+/// | "no-referrer-when-downgrade"      | Only send Referer for same-origin or more secure       |
+/// | "origin"                          | Send only the origin part of the URL                   |
+/// | "origin-when-cross-origin"        | Full URL for same-origin, origin only for cross-origin |
+/// | "same-origin"                     | Only send Referer for same-origin requests             |
+/// | "strict-origin"                   | Like origin, but only to equally secure destinations   |
+/// | "strict-origin-when-cross-origin" | Default policy with varying levels of restriction      |
+/// | "unsafe-url"                      | Always send the full URL                               |
+///
+pub fn referrerpolicy(value: String) -> Attribute(msg) {
+  attribute("referrerpolicy", value)
+}
+
+// IMAGE ATTRIBUTES ------------------------------------------------------------
+
+/// Specifies text that should be displayed when the image cannot be rendered.
+/// This attribute is essential for accessibility, providing context about the
+/// image to users who cannot see it, including those using screen readers.
+///
+pub fn alt(text: String) -> Attribute(msg) {
+  attribute("alt", text)
+}
+
+/// Specifies the URL of an image or resource to be used.
+///
+pub fn src(url: String) -> Attribute(msg) {
+  attribute("src", url)
+}
+
+/// Specifies a set of image sources for different display scenarios. This allows
+/// browsers to choose the most appropriate image based on factors like screen
+/// resolution and viewport size.
+///
+pub fn srcset(sources: String) -> Attribute(msg) {
+  attribute("srcset", sources)
+}
+
+/// Used with `srcset` to define the size of images in different layout scenarios.
+/// Helps the browser select the most appropriate image source.
+///
+pub fn sizes(value: String) -> Attribute(msg) {
+  attribute("sizes", value)
+}
+
+/// Configures the CORS (Cross-Origin Resource Sharing) settings for the element.
+/// Valid values are "anonymous" and "use-credentials".
+///
+pub fn crossorigin(value: String) -> Attribute(msg) {
+  attribute("crossorigin", value)
+}
+
+/// Specifies the name of an image map to be used with the image.
+///
+pub fn usemap(value: String) -> Attribute(msg) {
+  attribute("usemap", value)
+}
+
+/// Indicates that the image is a server-side image map. When a user clicks on the
+/// image, the coordinates of the click are sent to the server.
+///
+pub fn ismap(is_map: Bool) -> Attribute(msg) {
+  boolean_attribute("ismap", is_map)
+}
+
+/// Specifies the width of the element in pixels.
+///
+pub fn width(value: Int) -> Attribute(msg) {
+  property("width", json.int(value))
+}
+
+/// Specifies the height of the element in pixels.
+///
+pub fn height(value: Int) -> Attribute(msg) {
+  property("height", json.int(value))
+}
+
+/// Provides a hint about how the image should be decoded. Valid values are
+/// "sync", "async", and "auto".
+///
+pub fn decoding(value: String) -> Attribute(msg) {
+  attribute("decoding", value)
+}
+
+/// Indicates how the browser should load the image. Valid values are "eager"
+/// (load immediately) and "lazy" (defer loading until needed).
+///
+pub fn loading(value: String) -> Attribute(msg) {
+  attribute("loading", value)
+}
+
+/// Sets the priority for fetches initiated by the element. Valid values are
+/// "high", "low", and "auto".
+///
+pub fn fetchpriority(value: String) -> Attribute(msg) {
+  attribute("fetchpriority", value)
+}
+
+// FORM ATTRIBUTES -------------------------------------------------------------
+
+/// Specifies the character encodings to be used for form submission. This allows
+/// servers to know how to interpret the form data. Multiple encodings can be
+/// specified as a space-separated list.
+///
+pub fn accept_charset(charsets: String) -> Attribute(msg) {
+  attribute("accept-charset", charsets)
+}
+
+/// Specifies the URL to which the form's data should be sent when submitted.
+/// This can be overridden by formaction attributes on submit buttons.
+///
+pub fn action(url: String) -> Attribute(msg) {
+  attribute("action", url)
+}
+
+/// Specifies how form data should be encoded before sending it to the server.
+/// Valid values include:
+///
+/// | Value                             | Description                           |
+/// |-----------------------------------|---------------------------------------|
+/// | "application/x-www-form-urlencoded" | Default encoding (spaces as +, etc.)  |
+/// | "multipart/form-data"               | Required for file uploads             |
+/// | "text/plain"                        | Simple encoding with minimal escaping  |
+///
+pub fn enctype(encoding_type: String) -> Attribute(msg) {
+  attribute("enctype", encoding_type)
+}
+
+/// Specifies the HTTP method to use when submitting the form. Common values are:
+///
+/// | Value    | Description                                              |
+/// |----------|----------------------------------------------------------|
+/// | "get"    | Appends form data to URL (default)                       |
+/// | "post"   | Sends form data in the body of the HTTP request          |
+/// | "dialog" | Closes a dialog if the form is inside one                |
+///
+pub fn method(http_method: String) -> Attribute(msg) {
+  attribute("method", http_method)
+}
+
+/// When present, indicates that the form should not be validated when submitted.
+/// This allows submission of forms with invalid or incomplete data.
+///
+pub fn novalidate(disable_validation: Bool) -> Attribute(msg) {
+  boolean_attribute("novalidate", disable_validation)
+}
+
+// INPUT ATTRIBUTES ------------------------------------------------------------
+
+/// A hint for the user agent about what file types are expected to be submitted.
+/// The following values are accepted:
+///
+/// | Value     | Description                                          |
+/// |-----------|------------------------------------------------------|
+/// | "audio/*" | Any audio file type.                                 |
+/// | "video/*" | Any video file type.                                 |
+/// | "image/*" | Any image file type.                                 |
+/// | mime/type | A complete MIME type, without additional parameters. |
+/// | .ext      | Indicates any file with the given extension.         |
+///
+/// The following input types support the `"accept"` attribute:
+///
+/// - `"file"`
+///
+/// > **Note**: the `"accept"` attribute is a *hint* to the user agent and does
+/// > not guarantee that the user will only be able to select files of the specified
+/// > type.
+///
+pub fn accept(values: List(String)) -> Attribute(msg) {
+  attribute("accept", string.join(values, ","))
+}
+
+/// Allow a colour's alpha component to be manipulated, allowing the user to
+/// select a colour with transparency.
+///
+/// The following input types support the `"alpha"` attribute:
+///
+/// - `"color"`
+///
+pub fn alpha(allowed: Bool) -> Attribute(msg) {
+  boolean_attribute("alpha", allowed)
+}
+
+/// A hint for the user agent to automatically fill the value of the input with
+/// an appropriate value. The format for the `"autocomplete"` attribute is a
+/// space-separated ordered list of optional tokens:
+///
+///     "section-* (shipping | billing) [...fields] webauthn"
+///
+/// - `section-*`: used to disambiguate between two fields with otherwise identical
+///   autocomplete values. The `*` is replaced with a string that identifies the
+///   section of the form.
+///
+/// - `shipping | billing`: indicates the field is related to shipping or billing
+///   address or contact information.
+///
+/// - `[...fields]`: a space-separated list of field names that are relevant to
+///   the input, for example `"email"`, `"name family-name"`, or `"home tel"`.
+///
+/// - `webauthn`: indicates the field can be automatically filled with a WebAuthn
+///   passkey.
+///
+/// In addition, the value may instead be `"off"` to disable autocomplete for the
+/// input, or `"on"` to let the user agent decide based on context what values
+/// are appropriate.
+///
+/// The following input types support the `"autocomplete"` attribute:
+///
+/// - `"color"`
+/// - `"date"`
+/// - `"datetime-local"`
+/// - `"email"`
+/// - `"hidden"`
+/// - `"month"`
+/// - `"number"`
+/// - `"password"`
+/// - `"range"`
+/// - `"search"`
+/// - `"tel"`
+/// - `"text"`
+/// - `"time"`
+/// - `"url"`
+/// - `"week"`
+///
+pub fn autocomplete(value: String) -> Attribute(msg) {
+  attribute("autocomplete", value)
+}
+
+/// Whether the control is checked or not. When participating in a form, the
+/// value of the input is included in the form submission if it is checked. For
+/// checkboxes that do not have a value, the value of the input is `"on"` when
+/// checked.
+///
+/// The following input types support the `"checked"` attribute:
+///
+/// - `"checkbox"`
+/// - `"radio"`
+///
+pub fn checked(is_checked: Bool) -> Attribute(msg) {
+  boolean_attribute("checked", is_checked)
+}
+
+/// The color space of the serialised CSS color. It also hints to user agents
+/// about what kind of interface to present to the user for selecting a color.
+/// The following values are accepted:
+///
+/// - `"limited-srgb"`: The CSS color is converted to the 'srgb' color space and
+///   limited to 8-bits per component, e.g., `"#123456"` or
+///   `"color(srgb 0 1 0 / 0.5)"`.
+///
+/// - `"display-p3"`: The CSS color is converted to the 'display-p3' color space,
+///   e.g., `"color(display-p3 1.84 -0.19 0.72 / 0.6)"`.
+///
+/// The following input types support the `"colorspace"` attribute:
+///
+/// - `"color"`
+///
+pub fn colorspace(value: String) -> Attribute(msg) {
+  attribute("colorspace", value)
+}
+
+/// The name of the field included in a form that indicates the direcionality of
+/// the user's input.
+///
+/// The following input types support the `"dirname"` attribute:
+///
+/// - `"email"`
+/// - `"hidden"`
+/// - `"password"`
+/// - `"search"`
+/// - `"submit"
+/// - `"tel"`
+/// - `"text"`
+/// - `"url"`
+///
+pub fn dirname(direction: String) -> Attribute(msg) {
+  attribute("dirname", direction)
+}
+
+/// Controls whether or not the input is disabled. Disabled inputs are not
+/// validated during form submission and are not interactive.
+///
+pub fn disabled(is_disabled: Bool) -> Attribute(msg) {
+  boolean_attribute("disabled", is_disabled)
+}
+
+/// Associates the input with a form element located elsewhere in the document.
+///
+pub fn form(id: String) -> Attribute(msg) {
+  attribute("form", id)
+}
+
+/// The URL to use for form submission. This URL will override the [`"action"`](#action)
+/// attribute on the form element itself, if present.
+///
+/// The following input types support the `"formaction"` attribute:
+///
+/// - `"image"`
+/// - `"submit"`
+///
+pub fn formaction(url: String) -> Attribute(msg) {
+  attribute("formaction", url)
+}
+
+/// Entry list encoding type to use for form submission
+///
+/// - `"image"`
+/// - `"submit"`
+///
+pub fn formenctype(encoding_type: String) -> Attribute(msg) {
+  attribute("formenctype", encoding_type)
+}
+
+/// Variant to use for form submission
+///
+/// - `"image"`
+/// - `"submit"`
+///
+pub fn formmethod(method: String) -> Attribute(msg) {
+  attribute("formmethod", method)
+}
+
+/// Bypass form control validation for form submission
+///
+/// - `"image"`
+/// - `"submit"`
+///
+pub fn formnovalidate(no_validate: Bool) -> Attribute(msg) {
+  boolean_attribute("formnovalidate", no_validate)
+}
+
+/// Navigable for form submission
+///
+/// - `"image"`
+/// - `"submit"`
+///
+pub fn formtarget(target: String) -> Attribute(msg) {
+  attribute("formtarget", target)
+}
+
+/// List of autocomplete options
+///
+/// The following input types support the `"list"` attribute:
+///
+/// - `"color"`
+/// - `"date"`
+/// - `"datetime-local"`
+/// - `"email"`
+/// - `"month"`
+/// - `"number"`
+/// - `"range"`
+/// - `"search"`
+/// - `"tel"`
+/// - `"text"`
+/// - `"time"`
+/// - `"url"`
+/// - `"week"`
+///
+pub fn list(id: String) -> Attribute(msg) {
+  attribute("list", id)
+}
+
+/// Constrain the maximum value of a form control. The exact syntax of this value
+/// changes depending on the type of input, for example `"1"`, `"1979-12-31"`, and
+/// `"06:00"` are all potentially valid values for the `"max"` attribute.
+///
+/// The following input types support the `"max"` attribute:
+///
+/// - `"date"`
+/// - `"datetime-local"`
+/// - `"month"`
+/// - `"number"`
+/// - `"range"`
+/// - `"time"`
+/// - `"week"`
+///
+pub fn max(value: String) -> Attribute(msg) {
+  attribute("max", value)
+}
+
+/// Maximum length of value
+///
+/// The following input types support the `"maxlength"` attribute:
+///
+/// - `"email"`
+/// - `"password"`
+/// - `"search"`
+/// - `"tel"`
+/// - `"text"`
+/// - `"url"`
+///
+pub fn maxlength(length: Int) -> Attribute(msg) {
+  attribute("maxlength", int.to_string(length))
+}
+
+/// Minimum value
+///
+/// The following input types support the `"max"` attribute:
+///
+/// - `"date"`
+/// - `"datetime-local"`
+/// - `"month"`
+/// - `"number"`
+/// - `"range"`
+/// - `"time"`
+/// - `"week"`
+///
+pub fn min(value: String) -> Attribute(msg) {
+  attribute("min", value)
+}
+
+/// Minimum length of value
+///
+/// - `"email"`
+/// - `"password"`
+/// - `"search"`
+/// - `"tel"`
+/// - `"text"`
+/// - `"url"`
+///
+pub fn minlength(length: Int) -> Attribute(msg) {
+  attribute("minlength", int.to_string(length))
+}
+
+/// Whether an input or select may allow multiple values to be selected at once.
+///
+/// The following input types support the `"multiple"` attribute:
+///
+/// - `"email"`
+/// - `"file"`
+///
+pub fn multiple(allow_multiple: Bool) -> Attribute(msg) {
+  boolean_attribute("multiple", allow_multiple)
+}
+
+/// Name of the element to use for form submission and in the form.elements API
+///
+pub fn name(element_name: String) -> Attribute(msg) {
+  attribute("name", element_name)
+}
+
+/// Pattern to be matched by the form control's value
+///
+/// - `"email"`
+/// - `"password"`
+/// - `"search"`
+/// - `"tel"`
+/// - `"text"`
+/// - `"url"`
+///
+pub fn pattern(regex: String) -> Attribute(msg) {
+  attribute("pattern", regex)
+}
+
+/// User-visible label to be placed within the form control
+///
+/// - `"email"`
+/// - `"number"`
+/// - `"password"`
+/// - `"search"`
+/// - `"tel"`
+/// - `"text"`
+/// - `"url"`
+///
+pub fn placeholder(text: String) -> Attribute(msg) {
+  attribute("placeholder", text)
+}
+
+/// Targets a popover element to toggle, show, or hide
+///
+/// The following input types support the `"popovertarget"` attribute:
+///
+/// - `"button"`
+/// - `"image"`
+/// - `"reset"`
+/// - `"submit"`
+///
+pub fn popovertarget(id: String) -> Attribute(msg) {
+  attribute("popovertarget", id)
+}
+
+/// Indicates whether a targeted popover element is to be toggled, shown, or hidden
+///
+/// The following input types support the `"popovertarget"` attribute:
+///
+/// - `"button"`
+/// - `"image"`
+/// - `"reset"`
+/// - `"submit"`
+///
+pub fn popovertargetaction(action: String) -> Attribute(msg) {
+  attribute("popovertargetaction", action)
+}
+
+/// Whether to allow the value to be edited by the user
+///
+/// - `"date"`
+/// - `"datetime-local"`
+/// - `"email"`
+/// - `"month"`
+/// - `"number"`
+/// - `"password"`
+/// - `"range"`
+/// - `"search"`
+/// - `"tel"`
+/// - `"text"`
+/// - `"time"`
+/// - `"url"`
+/// - `"week"`
+///
+pub fn readonly(is_readonly: Bool) -> Attribute(msg) {
+  boolean_attribute("readonly", is_readonly)
+}
+
+/// Whether the control is required for form submission
+///
+/// - `"checkbox"`
+/// - `"date"`
+/// - `"datetime-local"`
+/// - `"email"`
+/// - `"month"`
+/// - `"number"`
+/// - `"password"`
+/// - `"radio"`
+/// - `"range"`
+/// - `"search"`
+/// - `"tel"`
+/// - `"text"`
+/// - `"time"`
+/// - `"url"`
+/// - `"week"`
+///
+pub fn required(is_required: Bool) -> Attribute(msg) {
+  boolean_attribute("required", is_required)
+}
+
+/// Controls whether or not a select's `<option>` is selected or not. Only one
+/// option can be selected at a time, unless the [`"multiple"`](#multiple)
+/// attribute is set on the select element.
+///
+pub fn selected(is_selected: Bool) -> Attribute(msg) {
+  boolean_attribute("selected", is_selected)
+}
+
+/// Size of the control
+///
+/// The following input types support the `size` attribute:
+///
+/// - `"email"`
+/// - `"password"`
+/// - `"search"`
+/// - `"tel"`
+/// - `"text"`
+/// - `"url"`
+///
+pub fn size(value: String) -> Attribute(msg) {
+  attribute("size", value)
+}
+
+/// Granularity to be matched by the form control's value
+///
+/// The following input types support the `"step"` attribute:
+///
+/// - `"date"`
+/// - `"datetime-local"`
+/// - `"month"`
+/// - `"number"`
+/// - `"range"`
+/// - `"time"`
+/// - `"week"`
+///
+pub fn step(value: String) -> Attribute(msg) {
+  attribute("step", value)
+}
+
+/// Type of form control
+///
+pub fn type_(control_type: String) -> Attribute(msg) {
+  attribute("type", control_type)
+}
+
+/// Value of the form control
+///
+pub fn value(control_value: String) -> Attribute(msg) {
+  attribute("value", control_value)
+}
+
+// META ATTRIBUTES -------------------------------------------------------------
+
+/// Sets a pragma directive for a document. This is used in meta tags to define
+/// behaviors the user agent should follow.
+///
+pub fn http_equiv(value: String) -> Attribute(msg) {
+  attribute("http-equiv", value)
+}
+
+/// Specifies the value of the meta element, which varies depending on the value
+/// of the name or http-equiv attribute.
+///
+pub fn content(value: String) -> Attribute(msg) {
+  attribute("content", value)
+}
+
+/// Declares the character encoding used in the document. When used with a meta
+/// element, this replaces the need for the `http_equiv("content-type")` attribute.
+///
+pub fn charset(value: String) -> Attribute(msg) {
+  attribute("charset", value)
+}
+
+/// Specifies the media types the resource applies to. This is commonly used with
+/// link elements for stylesheets to determine when they should be loaded.
+///
+pub fn media(query: String) -> Attribute(msg) {
+  attribute("media", query)
+}
+
+// AUDIO AND VIDEO ATTRIBUTES --------------------------------------------------
+
+/// Indicates that the media resource should automatically begin playing as soon
+/// as it can do so without stopping. When not present, the media will not
+/// automatically play until the user initiates playback.
+///
+/// > **Note**: Lustre's runtime augments this attribute. Whenever it is toggled
+/// > to true, the media will begin playing as if the element's `play()` method
+/// > was called.
+///
+pub fn autoplay(auto_play: Bool) -> Attribute(msg) {
+  boolean_attribute("autoplay", auto_play)
+}
+
+/// When present, this attribute shows the browser's built-in control panel for the
+/// media player, giving users control over playback, volume, seeking, and more.
+///
+pub fn controls(show_controls: Bool) -> Attribute(msg) {
+  boolean_attribute("controls", show_controls)
+}
+
+/// When present, this attribute indicates that the media should start over again
+/// from the beginning when it reaches the end.
+///
+pub fn loop(should_loop: Bool) -> Attribute(msg) {
+  boolean_attribute("loop", should_loop)
+}
+
+/// When present, this attribute indicates that the audio output of the media element
+/// should be initially silenced.
+///
+pub fn muted(is_muted: Bool) -> Attribute(msg) {
+  boolean_attribute("muted", is_muted)
+}
+
+/// Encourages the user agent to display video content within the element's
+/// playback area rather than in a separate window or fullscreen, especially on
+/// mobile devices.
+///
+/// This attribute only acts as a *hint* to the user agent, and setting this to
+/// false does not imply that the video will be played in fullscreen.
+///
+pub fn playsinline(play_inline: Bool) -> Attribute(msg) {
+  boolean_attribute("playsinline", play_inline)
+}
+
+/// Specifies an image to be shown while the video is downloading, or until the
+/// user hits the play button.
+///
+pub fn poster(url: String) -> Attribute(msg) {
+  attribute("poster", url)
+}
+
+/// Provides a hint to the browser about what the author thinks will lead to the
+/// best user experience. The following values are accepted:
+///
+/// | Value      | Description                                                      |
+/// |------------|------------------------------------------------------------------|
+/// | "auto"     | Let's the user agent determine the best option                   |
+/// | "metadata" | Hints to the user agent that it can fetch the metadata only.     |
+/// | "none"     | Hints to the user agent that server traffic should be minimised. |
+///
+pub fn preload(value: String) -> Attribute(msg) {
+  attribute("preload", value)
+}
+
+// TEMPLATE ATTRIBUTES ---------------------------------------------------------
+
+/// Specifies the mode for creating a shadow root on a template. Valid values
+/// include:
+///
+/// | Value     | Description                                 |
+/// |-----------|---------------------------------------------|
+/// | "open"    | Shadow root's contents are accessible       |
+/// | "closed"  | Shadow root's contents are not accessible   |
+///
+/// > **Note**: if you are pre-rendering a Lustre component you must make sure this
+/// > attribute matches the [`open_shadow_root`](./component.html#open_shadow_root)
+/// > configuration - or `"closed"` if not explicitly set - to ensure the shadow
+/// > root is created correctly.
+///
+pub fn shadowrootmode(mode: String) -> Attribute(msg) {
+  attribute("shadowrootmode", mode)
+}
+
+/// Indicates whether focus should be delegated to the shadow root when an element
+/// in the shadow tree gains focus.
+///
+pub fn shadowrootdelegatesfocus(delegates: Bool) -> Attribute(msg) {
+  boolean_attribute("shadowrootdelegatesfocus", delegates)
+}
+
+/// Determines whether the shadow root can be cloned when the host element is
+/// cloned.
+///
+pub fn shadowrootclonable(clonable: Bool) -> Attribute(msg) {
+  boolean_attribute("shadowrootclonable", clonable)
+}
+
+/// Controls whether the shadow root should be preserved during serialization
+/// operations like copying to the clipboard or saving a page.
+///
+pub fn shadowrootserializable(serializable: Bool) -> Attribute(msg) {
+  boolean_attribute("shadowrootserializable", serializable)
+}
+
+// ARIA ATTRIBUTES -------------------------------------------------------------
 
 /// Add an `aria-*` attribute to an HTML element. The key will be prefixed by
 /// `aria-`.

--- a/src/lustre/component.gleam
+++ b/src/lustre/component.gleam
@@ -77,8 +77,8 @@ pub opaque type Config(msg) {
 ///   you an experience similar to components in other frameworks like React or
 ///   Vue.
 ///
-/// **Note**: Not all options are available for server components. For example
-/// server components cannot be form-associated and participate in form submission.
+/// > **Note**: Not all options are available for server components. For example
+/// > server components cannot be form-associated and participate in form submission.
 ///
 pub opaque type Option(msg) {
   Option(apply: fn(Config(msg)) -> Config(msg))
@@ -154,9 +154,9 @@ pub fn on_property_change(name: String, decoder: Decoder(msg)) -> Option(msg) {
 /// in form submission and respond to additional form-specific events such as
 /// the form being reset or the browser autofilling this component's value.
 ///
-/// **Note**: form-associated components are not supported in server components
-/// for both technical and ideological reasons. If you'd like a component that
-/// participates in form submission, you should use a client component!
+/// > **Note**: form-associated components are not supported in server components
+/// > for both technical and ideological reasons. If you'd like a component that
+/// > participates in form submission, you should use a client component!
 ///
 pub fn form_associated() -> Option(msg) {
   use config <- Option
@@ -169,8 +169,8 @@ pub fn form_associated() -> Option(msg) {
 /// callback should convert the autofilled value into a message that you handle
 /// in your `update` function.
 ///
-/// **Note**: server components cannot participate in form submission and configuring
-/// this option will do nothing.
+/// > **Note**: server components cannot participate in form submission and configuring
+/// > this option will do nothing.
 ///
 pub fn on_form_autofill(handler: fn(String) -> msg) -> Option(msg) {
   use config <- Option
@@ -181,8 +181,8 @@ pub fn on_form_autofill(handler: fn(String) -> msg) -> Option(msg) {
 /// Set a message to be dispatched whenever a form containing this
 /// [form-associated](#form_associated) component is reset.
 ///
-/// **Note**: server components cannot participate in form submission and configuring
-/// this option will do nothing.
+/// > **Note**: server components cannot participate in form submission and configuring
+/// > this option will do nothing.
 ///
 pub fn on_form_reset(msg: msg) -> Option(msg) {
   use config <- Option
@@ -194,8 +194,8 @@ pub fn on_form_reset(msg: msg) -> Option(msg) {
 /// [form-associated](#form_associated) component's `"value"` attribute. This is
 /// often triggered when the user navigates back or forward in their history.
 ///
-/// **Note**: server components cannot participate in form submission and configuring
-/// this option will do nothing.
+/// > **Note**: server components cannot participate in form submission and configuring
+/// > this option will do nothing.
 ///
 pub fn on_form_restore(handler: fn(String) -> msg) -> Option(msg) {
   use config <- Option

--- a/src/lustre/effect.gleam
+++ b/src/lustre/effect.gleam
@@ -138,13 +138,13 @@ pub fn from(effect: fn(fn(msg) -> Nil) -> Nil) -> Effect(msg) {
 /// the state of the DOM, update your model, and then render a second time with
 /// the additional information.
 ///
-/// **Note**: dispatching messages synchronously in this effect can lead to
-/// degraded performance if not used correctly. In the worst case you can lock
-/// up the browser and prevent it from painting the screen _at all_.
+/// > **Note**: dispatching messages synchronously in this effect can lead to
+/// > degraded performance if not used correctly. In the worst case you can lock
+/// > up the browser and prevent it from painting the screen _at all_.
 ///
-/// **Note**: There is no concept of a "paint" for server components. Using this
-/// effect in those contexts will run the effect synchronously, after any non-timing
-/// effects are processed.
+/// > **Note**: There is no concept of a "paint" for server components. Using this
+/// > effect in those contexts will run the effect synchronously, after any non-timing
+/// > effects are processed.
 ///
 pub fn before_paint(effect: fn(fn(msg) -> Nil) -> Nil) -> Effect(msg) {
   Effect(..empty, before_paint: [task(effect)])
@@ -153,9 +153,9 @@ pub fn before_paint(effect: fn(fn(msg) -> Nil) -> Nil) -> Effect(msg) {
 /// Schedule a side effect that is guaranteed to run after the browser has painted
 /// the screen.
 ///
-/// **Note**: There is no concept of a "paint" for server components. Using this
-/// effect in those contexts will run the effect synchronously, after any non-timing
-/// effects and any `before_paint` effects are processed.
+/// > **Note**: There is no concept of a "paint" for server components. Using this
+/// > effect in those contexts will run the effect synchronously, after any non-timing
+/// > effects and any `before_paint` effects are processed.
 ///
 pub fn after_paint(effect: fn(fn(msg) -> Nil) -> Nil) -> Effect(msg) {
   Effect(..empty, after_paint: [task(effect)])
@@ -211,15 +211,15 @@ pub fn with_element_internals(
 
 /// Batch multiple effects to be performed at the same time.
 ///
-/// **Note**: The runtime makes no guarantees about the order on which effects
-/// are performed! If you need to chain or sequence effects together, you have
-/// two broad options:
-///
-/// 1. Create variants of your `msg` type to represent each step in the sequence
-///    and fire off the next effect in response to the previous one.
-///
-/// 2. If you're defining effects yourself, consider whether or not you can handle
-///    the sequencing inside the effect itself.
+/// > **Note**: The runtime makes no guarantees about the order on which effects
+/// > are performed! If you need to chain or sequence effects together, you have
+/// > two broad options:
+/// >
+/// > 1. Create variants of your `msg` type to represent each step in the sequence
+/// >    and fire off the next effect in response to the previous one.
+/// >
+/// > 2. If you're defining effects yourself, consider whether or not you can handle
+/// >    the sequencing inside the effect itself.
 ///
 pub fn batch(effects: List(Effect(msg))) -> Effect(msg) {
   use acc, eff <- list.fold(effects, empty)
@@ -233,8 +233,8 @@ pub fn batch(effects: List(Effect(msg))) -> Effect(msg) {
 /// Transform the result of an effect. This is useful for mapping over effects
 /// produced by other libraries or modules.
 ///
-/// **Note**: Remember that effects are not _required_ to dispatch any messages.
-/// Your mapping function may never be called!
+/// > **Note**: Remember that effects are not _required_ to dispatch any messages.
+/// > Your mapping function may never be called!
 ///
 pub fn map(effect: Effect(a), f: fn(a) -> b) -> Effect(b) {
   Effect(
@@ -280,11 +280,11 @@ fn do_comap_select(_, _, _) -> Nil {
 /// This is primarily used internally by the server component runtime, but it is
 /// may also useful for testing.
 ///
-/// **Note**: For now, you should **not** consider this function a part of the
-/// public API. It may be removed in a future minor or patch release. If you have
-/// a specific use case for this function, we'd love to hear about it! Please
-/// reach out on the [Gleam Discord](https://discord.gg/Fm8Pwmy) or
-/// [open an issue](https://github.com/lustre-labs/lustre/issues/new)!
+/// > **Note**: For now, you should **not** consider this function a part of the
+/// > public API. It may be removed in a future minor or patch release. If you have
+/// > a specific use case for this function, we'd love to hear about it! Please
+/// > reach out on the [Gleam Discord](https://discord.gg/Fm8Pwmy) or
+/// > [open an issue](https://github.com/lustre-labs/lustre/issues/new)!
 ///
 @internal
 pub fn perform(

--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -22,9 +22,9 @@ import lustre/vdom/vnode.{Element, Fragment, Text, UnsafeInnerHtml}
 /// variable is used to represent the types of messages that can be produced from
 /// events on the element or its children.
 ///
-/// **Note**: Just because an element _can_ produces messages of a given type,
-/// doesn't mean that it _will_! The `msg` type variable is used to represent the
-/// potential for messages to be produced, not a guarantee.
+/// > **Note**: Just because an element _can_ produces messages of a given type,
+/// > doesn't mean that it _will_! The `msg` type variable is used to represent the
+/// > potential for messages to be produced, not a guarantee.
 ///
 /// The most basic ways to create elements are:
 ///
@@ -73,29 +73,29 @@ pub type Element(msg) =
 /// function is particularly handy when constructing custom elements, either
 /// from your own Lustre components or from external JavaScript libraries.
 ///
-/// **Note**: Because Lustre is primarily used to create HTML, this function
-/// special-cases the following tags which render as
-/// [void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element):
-///
-///   - area
-///   - base
-///   - br
-///   - col
-///   - embed
-///   - hr
-///   - img
-///   - input
-///   - link
-///   - meta
-///   - param
-///   - source
-///   - track
-///   - wbr
-///
-///  This will only affect the output of `to_string` and `to_string_builder`!
-///  If you need to render any of these tags with children, *or* you want to
-///  render some other tag as self-closing or void, use [`advanced`](#advanced)
-///  to construct the element instead.
+/// > **Note**: Because Lustre is primarily used to create HTML, this function
+/// > special-cases the following tags which render as
+/// > [void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element):
+/// >
+/// >   - area
+/// >   - base
+/// >   - br
+/// >   - col
+/// >   - embed
+/// >   - hr
+/// >   - img
+/// >   - input
+/// >   - link
+/// >   - meta
+/// >   - param
+/// >   - source
+/// >   - track
+/// >   - wbr
+/// >
+/// > This will only affect the output of `to_string` and `to_string_builder`!
+/// > If you need to render any of these tags with children, *or* you want to
+/// > render some other tag as self-closing or void, use [`advanced`](#advanced)
+/// > to construct the element instead.
 ///
 pub fn element(
   tag: String,

--- a/src/lustre/element/keyed.gleam
+++ b/src/lustre/element/keyed.gleam
@@ -67,9 +67,9 @@ import lustre/vdom/vnode
 /// a single child can be moved around such as in a to-do list, or when elements
 /// are frequently added or removed.
 ///
-/// **Note**: the key for each child must be unique within the list of children,
-/// but it doesn't have to be unique across the whole application. It's fine to
-/// use the same key in different lists.
+/// > **Note**: the key for each child must be unique within the list of children,
+/// > but it doesn't have to be unique across the whole application. It's fine to
+/// > use the same key in different lists.
 ///
 pub fn element(
   tag: String,
@@ -96,9 +96,9 @@ pub fn element(
 /// This is useful when a single child can be moved around such as in a to-do
 /// list, or when elements are frequently added or removed.
 ///
-/// **Note**: the key for each child must be unique within the list of children,
-/// but it doesn't have to be unique across the whole application. It's fine to
-/// use the same key in different lists.
+/// > **Note**: the key for each child must be unique within the list of children,
+/// > but it doesn't have to be unique across the whole application. It's fine to
+/// > use the same key in different lists.
 ///
 pub fn namespaced(
   namespace: String,
@@ -126,9 +126,9 @@ pub fn namespaced(
 /// can be moved around such as in a to-do list, or when elements are frequently
 /// added or removed.
 ///
-/// **Note**: the key for each child must be unique within the list of children,
-/// but it doesn't have to be unique across the whole application. It's fine to
-/// use the same key in different lists.
+/// > **Note**: the key for each child must be unique within the list of children,
+/// > but it doesn't have to be unique across the whole application. It's fine to
+/// > use the same key in different lists.
 ///
 pub fn fragment(children: List(#(String, Element(msg)))) -> Element(msg) {
   let #(keyed_children, children, children_count) =

--- a/src/lustre/event.gleam
+++ b/src/lustre/event.gleam
@@ -4,6 +4,7 @@ import gleam/dynamic/decode.{type Decoder}
 import gleam/json.{type Json}
 import lustre/attribute.{type Attribute}
 import lustre/effect.{type Effect}
+import lustre/internals/constants
 import lustre/vdom/vattr.{Debounce, Event, Throttle}
 
 // EFFECTS ---------------------------------------------------------------------
@@ -28,12 +29,28 @@ pub fn emit(event: String, data: Json) -> Effect(msg) {
 /// If you're listening for non-standard events (like those emitted by a custom
 /// element) their event names might be slightly different.
 ///
-/// **Note**: if you are developing a server component, it is important to also
-/// use [`server_component.include`](./server_component.html#include) to state
-/// which properties of the event you need to be sent to the server.
+/// > **Note**: if you are developing a server component, it is important to also
+/// > use [`server_component.include`](./server_component.html#include) to state
+/// > which properties of the event you need to be sent to the server.
 ///
 pub fn on(name: String, handler: Decoder(msg)) -> Attribute(msg) {
-  attribute.on(name, handler)
+  vattr.event(
+    name:,
+    handler:,
+    include: constants.empty_list,
+    prevent_default: False,
+    stop_propagation: False,
+    immediate: is_immediate_event(name),
+    limit: vattr.NoLimit(kind: 0),
+  )
+}
+
+fn is_immediate_event(name: String) -> Bool {
+  case name {
+    "input" | "change" | "focus" | "focusin" | "focusout" | "blur" | "select" ->
+      True
+    _ -> False
+  }
 }
 
 /// Indicate that the event should have its default behaviour cancelled. This is
@@ -68,9 +85,9 @@ pub fn stop_propagation(event: Attribute(msg)) -> Attribute(msg) {
 /// This is particularly useful for server components where many events in quick
 /// succession can introduce problems because of network latency.
 ///
-/// **Note**: debounced events inherently introduce latency. Try to consider
-/// typical interaction patterns and experiment with different delays to balance
-/// responsiveness and update frequency.
+/// > **Note**: debounced events inherently introduce latency. Try to consider
+/// > typical interaction patterns and experiment with different delays to balance
+/// > responsiveness and update frequency.
 ///
 pub fn debounce(event: Attribute(msg), delay: Int) -> Attribute(msg) {
   case event {
@@ -92,9 +109,9 @@ pub fn debounce(event: Attribute(msg), delay: Int) -> Attribute(msg) {
 /// This is particularly useful for server components where many events in quick
 /// succession can introduce problems because of network latency.
 ///
-/// **Note**: throttled events inherently reduce precision. Try to consider
-/// typical interaction patterns and experiment with different delays to balance
-/// responsiveness and update frequency.
+/// > **Note**: throttled events inherently reduce precision. Try to consider
+/// > typical interaction patterns and experiment with different delays to balance
+/// > responsiveness and update frequency.
 ///
 pub fn throttle(event: Attribute(msg), delay: Int) -> Attribute(msg) {
   case event {

--- a/src/lustre/server_component.gleam
+++ b/src/lustre/server_component.gleam
@@ -46,10 +46,10 @@
 ////                            +----------------+
 //// ```
 ////
-//// **Note**: Lustre's server component runtime is separate from your application's
-//// WebSocket server. You're free to bring your own stack, connect multiple
-//// clients to the same Lustre instance, or keep the application alive even when
-//// no clients are connected.
+//// > **Note**: Lustre's server component runtime is separate from your application's
+//// > WebSocket server. You're free to bring your own stack, connect multiple
+//// > clients to the same Lustre instance, or keep the application alive even when
+//// > no clients are connected.
 ////
 //// Lustre server components run next to the rest of your backend code, your
 //// services, your database, etc. Real-time applications like chat services, games,
@@ -121,10 +121,10 @@ pub type TransportMethod {
 ///   and server runtime. Other options include `ServerSentEvents` and `Polling`
 ///   which are unidirectional transports.
 ///
-/// **Note**: the server component runtime bundle must be included and sent to
-/// the client for this to work correctly. You can do this by including the
-/// JavaScript bundle found in Lustre's `priv/static` directory or by inlining
-/// the script source directly with the [`script`](#script) element below.
+/// > **Note**: the server component runtime bundle must be included and sent to
+/// > the client for this to work correctly. You can do this by including the
+/// > JavaScript bundle found in Lustre's `priv/static` directory or by inlining
+/// > the script source directly with the [`script`](#script) element below.
 ///
 pub fn element(
   attributes: List(Attribute(msg)),
@@ -213,8 +213,8 @@ pub fn include(
 /// different `Subject`s to send messages to your application, take a look at the
 /// [`select`](#select) effect.
 ///
-/// **Note**: this function will always fail on the JavaScript target with the
-/// `NotErlang` error.
+/// > **Note**: this function will always fail on the JavaScript target with the
+/// > `NotErlang` error.
 ///
 pub fn subject(
   runtime: Runtime(msg),
@@ -242,8 +242,8 @@ fn coerce(value: a) -> b
 /// component runtime. The process that owns this will be monitored and the
 /// subject will be gracefully removed if the process dies.
 ///
-/// **Note**: if you are developing a server component for the JavaScript runtime,
-/// you should use [`register_callback`](#register_callback) instead.
+/// > **Note**: if you are developing a server component for the JavaScript runtime,
+/// > you should use [`register_callback`](#register_callback) instead.
 ///
 pub fn register_subject(
   runtime: Subject(RuntimeMessage(msg)),
@@ -293,9 +293,9 @@ fn do_deregister_subject(_, _) -> Nil {
 /// produces a message. Avoid using anonymous functions with this function, as
 /// they cannot later be removed using [`deregister_callback`](#deregister_callback).
 ///
-/// **Note**: server components running on the Erlang target are **strongly**
-/// encouraged to use [`register_subject`](#register_subject) instead of this
-/// function.
+/// > **Note**: server components running on the Erlang target are **strongly**
+/// > encouraged to use [`register_subject`](#register_subject) instead of this
+/// > function.
 ///
 pub fn register_callback(
   runtime: Runtime(msg),
@@ -308,9 +308,9 @@ pub fn register_callback(
 /// produces a message. The callback to remove is determined by function equality
 /// and must be the same function that was passed to [`register_callback`](#register_callback).
 ///
-/// **Note**: server components running on the Erlang target are **strongly**
-/// encouraged to use [`register_subject`](#register_subject) instead of this
-/// function.
+/// > **Note**: server components running on the Erlang target are **strongly**
+/// > encouraged to use [`register_subject`](#register_subject) instead of this
+/// > function.
 ///
 pub fn deregister_callback(
   runtime: Runtime(msg),
@@ -349,8 +349,8 @@ pub fn emit(event: String, data: Json) -> Effect(msg) {
 /// for later use. For example you may subscribe to a pubsub service and later use
 /// that same `Subject` to unsubscribe.
 ///
-/// **Note**: This effect does nothing on the JavaScript runtime, where `Subject`s
-/// and `Selector`s don't exist, and is the equivalent of returning `effect.none()`.
+/// > **Note**: This effect does nothing on the JavaScript runtime, where `Subject`s
+/// > and `Selector`s don't exist, and is the equivalent of returning `effect.none()`.
 ///
 pub fn select(
   sel: fn(fn(msg) -> Nil, Subject(a)) -> Selector(msg),

--- a/src/lustre/vdom/patch.gleam
+++ b/src/lustre/vdom/patch.gleam
@@ -42,9 +42,9 @@ pub type Patch(msg) {
 /// or removing its children).
 ///
 ///
-/// **Note**: when constructing a `Change` you should **always** use the provided
-/// constructors to ensure that the `kind` field is set correctly, never construct
-/// a variant directly.
+/// > **Note**: when constructing a `Change` you should **always** use the provided
+/// > constructors to ensure that the `kind` field is set correctly, never construct
+/// > a variant directly.
 ///
 pub type Change(msg) {
   // Self upadates:


### PR DESCRIPTION
Closes #284 and partially #283. It turns out finding a reference for All The Attributes is quite difficult. This PR expands the number of attributes Lustre provides to ~150 including ARIA attributes. Many but not all of these attributes have hand-written documentation inspired by the spec. The remaining attributes have a brief doc comment sourced from the spec directly.

When I started this work I removed all the attributes currently in the module so I could better organise things, it's possible we lost some along the way.