### PR TITLE
:recycle: use a synced attribute instead of conditionally rendering width/height as an attribute or property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ request to fix it.
 
 ### Changed
 
-- [lustre/attribute] The `width` and `height` attributes now conditionally use either the `attribute` or `property` based on the environment.
+- [lustre/attribute] The `width` and `height` attributes are now synced to their respective properties.
 - [lustre/element] Fixed a bug in `element.map` where the mapper functions were composed in reversed order.
 
 ## [5.0.2] - 2025-04-20

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -622,24 +622,13 @@ pub fn ismap(is_map: Bool) -> Attribute(msg) {
 /// Specifies the width of the element in pixels.
 ///
 pub fn width(value: Int) -> Attribute(msg) {
-  case is_browser() {
-    True -> property("width", json.int(value))
-    False -> attribute("width", int.to_string(value))
-  }
+  attribute("width", int.to_string(value))
 }
 
 /// Specifies the height of the element in pixels.
 ///
 pub fn height(value: Int) -> Attribute(msg) {
-  case is_browser() {
-    True -> property("width", json.int(value))
-    False -> attribute("width", int.to_string(value))
-  }
-}
-
-@external(javascript, "./runtime/client/runtime.ffi.mjs", "is_browser")
-fn is_browser() -> Bool {
-  False
+  attribute("height", int.to_string(value))
 }
 
 /// Provides a hint about how the image should be decoded. Valid values are

--- a/src/lustre/vdom/reconciler.ffi.mjs
+++ b/src/lustre/vdom/reconciler.ffi.mjs
@@ -586,7 +586,9 @@ const syncedBooleanAttribute = (name) => {
 const syncedAttribute = (name) => {
   return {
     added(node, value) {
-      node[name] = value;
+      try {
+        node[name] = value;
+      } catch (_) {}
     },
   };
 };

--- a/src/lustre/vdom/reconciler.ffi.mjs
+++ b/src/lustre/vdom/reconciler.ffi.mjs
@@ -595,6 +595,8 @@ const ATTRIBUTE_HOOKS = {
   checked: syncedBooleanAttribute("checked"),
   selected: syncedBooleanAttribute("selected"),
   value: syncedAttribute("value"),
+  width: syncedAttribute('width'),
+  height: syncedAttribute('height'),
 
   autofocus: {
     added(node) {


### PR DESCRIPTION
I think this is better overall, since it means it will work consistently in all runtimes and will allow both of them to also work on SVG and MathML elements.
 