### PR TITLE
Add `attribute.default_value` attribute for uncontrolled inputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ request to fix it.
 
 ## [Unreleased]
 
+### Added
+
+- [lustre/attribute] Added a `attribute.default_value` function to set the `defaultValue` property of an input.
+
 ## [5.0.3] - 2025-05-09
 
 ### Changed

--- a/birdie_snapshots/[html]_default_value_attribute_should_be_rendered_as_value_attribute.accepted
+++ b/birdie_snapshots/[html]_default_value_attribute_should_be_rendered_as_value_attribute.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.6
+title: [html] Default value attribute should be rendered as value attribute
+---
+<input type="text" value="Hello, world!">

--- a/examples/02-inputs/04-forms/src/app.gleam
+++ b/examples/02-inputs/04-forms/src/app.gleam
@@ -114,7 +114,7 @@ fn view_login(form: Form) -> Element(Msg) {
       attribute.class("p-8 w-full border rounded-2xl shadow-lg space-y-4"),
       // The message provided to the built-in `on_submit` handler receives the
       // `FormData` associated with the form as a List of (name, value) tuples.
-      // 
+      //
       // The event handler also calls `preventDefault()` on the form, such that
       // Lustre can handle the submission instead off being sent off to the server.
       event.on_submit(UserSubmittedForm),
@@ -172,9 +172,6 @@ fn view_input(
       // the `name` attribute is used as the first element of the tuple
       // we receive for this input.
       attribute.name(name),
-      // Associating a value with this element does _not_ make the element
-      // controlled without an event listener, allowing us to set a default.
-      attribute.value(form.value(form, name)),
     ]),
     // formal provides us with a customisable error message for every element
     // in case its validation fails, which we can show right below the input.

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -1141,10 +1141,29 @@ pub fn type_(control_type: String) -> Attribute(msg) {
   attribute("type", control_type)
 }
 
-/// Value of the form control
+/// Specifies the value of an input or form control. Using this attribute will
+/// make sure the value is always in sync with your application's modelled, a
+/// practice known as [_controlled inputs_](https://github.com/lustre-labs/lustre/blob/main/pages/hints/controlled-vs-uncontrolled-inputs.md).
+///
+/// If you'd like to let the DOM manage the value of an input but still set a
+/// default value for users to see, use the [`default_value`](#default_value)
+/// attribute instead.
 ///
 pub fn value(control_value: String) -> Attribute(msg) {
   attribute("value", control_value)
+}
+
+/// Set the default value of an input or form control. This is the value that will
+/// be shown to users when the input is first rendered and included in the form
+/// submission if the user does not change it.
+///
+/// Just setting a default value and letting the DOM manage the state of an input
+/// is known as using [_uncontrolled inputs]((https://github.com/lustre-labs/lustre/blob/main/pages/hints/controlled-vs-uncontrolled-inputs.md).
+/// Doing this means your application cannot set the value of an input after it
+/// is modified without using an effect.
+///
+pub fn default_value(control_value: String) -> Attribute(msg) {
+  attribute("virtual:defaultValue", control_value)
 }
 
 // META ATTRIBUTES -------------------------------------------------------------

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -1158,7 +1158,7 @@ pub fn value(control_value: String) -> Attribute(msg) {
 /// submission if the user does not change it.
 ///
 /// Just setting a default value and letting the DOM manage the state of an input
-/// is known as using [_uncontrolled inputs]((https://github.com/lustre-labs/lustre/blob/main/pages/hints/controlled-vs-uncontrolled-inputs.md).
+/// is known as using [_uncontrolled inputs](https://github.com/lustre-labs/lustre/blob/main/pages/hints/controlled-vs-uncontrolled-inputs.md).
 /// Doing this means your application cannot set the value of an input after it
 /// is modified without using an effect.
 ///

--- a/test/tests/html_test.gleam
+++ b/test/tests/html_test.gleam
@@ -1,6 +1,7 @@
 // IMPORTS ---------------------------------------------------------------------
 
 import birdie
+import lustre/attribute
 import lustre/element.{type Element}
 import lustre/element/html
 import lustre/element/keyed
@@ -200,6 +201,21 @@ pub fn deep_keyed_fragment_children_prefixes_test() {
   |> snapshot(
     "Keyed children are still prefixed if there is a non-prefixed fragment in-between",
   )
+}
+
+// ATTRIBUTE TESTS -------------------------------------------------------------
+
+pub fn default_value_attribute_test() {
+  use <- lustre_test.test_filter("default_value_attribute_test")
+
+  let input =
+    html.input([
+      attribute.type_("text"),
+      attribute.default_value("Hello, world!"),
+    ])
+
+  input
+  |> snapshot("Default value attribute should be rendered as value attribute")
 }
 
 // UTILS -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #316. This involves special-casing both the reconciler and the `to_string` implementation for attributes.

The reconciler needs special-casing because we don't want to actually set an attribute at all, we want to set the `defaultValue` property.

The `to_string` implementation needs special-casing because we want to render this attribute as a plain ol' `value` attribute.