### PR TITLE
:zap: use `previousSibling` when updating adjacent elements in the reconciler

### DIFF
--- a/src/lustre/vdom/reconciler.ffi.mjs
+++ b/src/lustre/vdom/reconciler.ffi.mjs
@@ -135,10 +135,19 @@ export class Reconciler {
         );
       }
 
+      let lastIndex = -1;
+      let lastChild = null;
       iterate(patch.children, (child) => {
-        // TODO: use linked-list style but skip to indices if distance is great enough?
+        const index = child.index|0;
+        
+        const next = lastChild && lastIndex - index === 1
+          ? lastChild.previousSibling
+          : childAt(node, index);
 
-        self.#stack.push({ node: childAt(node, child.index), patch: child });
+        self.#stack.push({ node: next, patch: child });
+
+        lastChild = next;
+        lastIndex = index;
       });
     }
   }


### PR DESCRIPTION
close #307 

I'm not sure even this change is worth it. The differences seem minimal except for in Chrome, and from some light testing (running example apps) it looks like it doesn't get hit all that often.