### PR TITLE
Fix #331

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ request to fix it.
 - [lustre/event] Fixed a bug where setting `prevent_default` on an existing event listener would not remove the passive flag.
 - [lustre/event] Fixed a bug where `throttle` would only work when used in combination with `debounce`.
 - [lustre/event] Fixed a bug where `throttle` would incorrectly call `.preventDefault` on all discarded events.
+- [lustre/element] Fixed a bug where nested fragments would sometimes not be properly replaced
 
 ## [v5.1.0] - 2025-05-18
 

--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -197,12 +197,10 @@ pub fn fragment(children: List(Element(msg))) -> Element(msg) {
 
 fn count_fragment_children(children: List(Element(msg)), count: Int) -> Int {
   case children {
+    [child, ..rest] ->
+      count_fragment_children(rest, count + vnode.advance(child))
+
     [] -> count
-
-    [Fragment(children_count:, ..), ..rest] ->
-      count_fragment_children(rest, count + children_count)
-
-    [_, ..rest] -> count_fragment_children(rest, count + 1)
   }
 }
 

--- a/test/integration/reconciler_test.gleam
+++ b/test/integration/reconciler_test.gleam
@@ -249,9 +249,9 @@ pub fn reconciler_push_nested_fragment_child_replaced_test() {
 }
 
 @target(javascript)
-pub fn reconciler_push_nested_fragment_children_removed_test() {
+pub fn reconciler_push_fragment_children_removed_test() {
   use <- lustre_test.test_filter(
-    "reconciler_push_nested_fragment_children_removed_test",
+    "reconciler_push_fragment_children_removed_test",
   )
 
   let prev =
@@ -261,6 +261,31 @@ pub fn reconciler_push_nested_fragment_children_removed_test() {
     ])
 
   let next = html.div([], [element.fragment([html.h1([], [])]), html.p([], [])])
+
+  test_diff(prev, next)
+}
+
+@target(javascript)
+pub fn reconciler_push_nested_fragment_children_removed_test() {
+  use <- lustre_test.test_filter(
+    "reconciler_push_nested_fragment_children_removed_test",
+  )
+
+  let prev =
+    html.div([], [
+      element.fragment([
+        element.fragment([html.h1([], []), html.p([], [])]),
+        html.p([attribute.class("a")], []),
+        html.p([attribute.class("b")], []),
+      ]),
+      html.p([], []),
+    ])
+
+  let next =
+    html.div([], [
+      element.fragment([html.h1([], []), html.p([attribute.class("a")], [])]),
+      html.div([], []),
+    ])
 
   test_diff(prev, next)
 }

--- a/test/unit/diff_test.gleam
+++ b/test/unit/diff_test.gleam
@@ -59,7 +59,7 @@ pub fn text_to_element_replacement_test() {
   |> should.equal(diff)
 }
 
-// // NODE DIFFS ------------------------------------------------------------------
+// NODE DIFFS ------------------------------------------------------------------
 
 pub fn nested_attribute_changes_test() {
   use <- lustre_test.test_filter("nested_attribute_changes_test")
@@ -268,8 +268,8 @@ pub fn nested_fragment_child_replaced_test() {
   |> should.equal(diff)
 }
 
-pub fn nested_fragment_children_removed_test() {
-  use <- lustre_test.test_filter("nested_fragment_children_removed_test")
+pub fn fragment_children_removed_test() {
+  use <- lustre_test.test_filter("fragment_children_removed_test")
 
   let prev =
     html.div([], [
@@ -281,6 +281,43 @@ pub fn nested_fragment_children_removed_test() {
 
   let diff =
     patch.new(0, 0, [], [patch.new(0, 0, [patch.remove(from: 2, count: 2)], [])])
+
+  diff.diff(events.new(), prev, next).patch
+  |> should.equal(diff)
+}
+
+pub fn nested_fragment_children_removed_test() {
+  use <- lustre_test.test_filter("nested_fragment_children_removed_test")
+
+  let prev =
+    html.div([], [
+      element.fragment([
+        element.fragment([html.h1([], []), html.p([], [])]),
+        html.p([], []),
+        html.p([], []),
+      ]),
+      html.p([], []),
+    ])
+
+  let next =
+    html.div([], [
+      element.fragment([html.h1([], []), html.p([], [])]),
+      html.div([], []),
+    ])
+
+  let diff =
+    patch.new(0, 0, [], [
+      patch.new(
+        0,
+        0,
+        [
+          patch.replace(from: 6, count: 1, with: html.div([], [])),
+          patch.replace(from: 1, count: 3, with: html.h1([], [])),
+          patch.remove(from: 3, count: 1),
+        ],
+        [],
+      ),
+    ])
 
   diff.diff(events.new(), prev, next).patch
   |> should.equal(diff)


### PR DESCRIPTION
Rewrote the fragment counting code to also use `vnode.advance` now. I think that previously caused a circular dependency.

fix #331 