### PR TITLE
Fix Typo

### DIFF
--- a/src/lustre/dev/simulate.gleam
+++ b/src/lustre/dev/simulate.gleam
@@ -76,7 +76,7 @@ pub type Event(msg) {
 /// your app's `init` function.
 ///
 /// DOM events and messages dispatched by effects can be simulated using the
-/// [`event`](#event) and [`messgae`](#message) functions.
+/// [`event`](#event) and [`message`](#message) functions.
 ///
 pub fn simple(
   init init: fn(args) -> model,
@@ -95,7 +95,7 @@ pub fn simple(
 /// your app's `init` function.
 ///
 /// DOM events and messages dispatched by effects can be simulated using the
-/// [`event`](#event) and [`messgae`](#message) functions.
+/// [`event`](#event) and [`message`](#message) functions.
 ///
 /// > **Note**: simulated apps do not run any effects! You can simulate the result
 /// > of an effect by using the [`message`](#message) function, but to test side

--- a/src/lustre/runtime/server/runtime.ffi.mjs
+++ b/src/lustre/runtime/server/runtime.ffi.mjs
@@ -53,7 +53,7 @@ export class Runtime {
       case ClientDispatchedMessage:
         switch (message.message.constructor) {
           case AttributeChanged: {
-            const { name, value } = message.messgae;
+            const { name, value } = message.message;
             let effects = [];
 
             const decoder = this.#on_attribute_change.get(name);


### PR DESCRIPTION
Hello! :wave:

I was poking around the FFI logic (looking for inspiration on how to consume an SSE `EventSource` from a Lustre web component), and I believe I stumbled across a typo. I expected to find two call sites though, rather than just the one, so I'm not sure where it's originating, so please advise if this rename away from the typo might break something elsewhere.

Cheers,
Brad

PS - Thanks so much for squashing #267! And congrats on v5! :rocket: :tada: 