### PR TITLE
:recycle: move Spa.start function outside of its class

### DIFF
--- a/src/lustre/runtime/client/spa.ffi.mjs
+++ b/src/lustre/runtime/client/spa.ffi.mjs
@@ -13,19 +13,6 @@ import { document } from "../../internals/constants.ffi.mjs";
 //
 
 export class Spa {
-  static start({ init, update, view }, selector, flags) {
-    if (!is_browser()) return new Error(new NotABrowser());
-
-    const root =
-      selector instanceof HTMLElement
-        ? selector
-        : document().querySelector(selector);
-
-    if (!root) return new Error(new ElementNotFound(selector));
-
-    return new Ok(new Spa(root, init(flags), update, view));
-  }
-
   #runtime;
 
   constructor(root, [init, effects], update, view) {
@@ -59,4 +46,15 @@ export class Spa {
   }
 }
 
-export const start = Spa.start;
+export const start = ({ init, update, view }, selector, flags) => {
+  if (!is_browser()) return new Error(new NotABrowser());
+
+  const root =
+    selector instanceof HTMLElement
+      ? selector
+      : document().querySelector(selector);
+
+  if (!root) return new Error(new ElementNotFound(selector));
+
+  return new Ok(new Spa(root, init(flags), update, view));
+}

--- a/src/lustre/vdom/reconciler.ffi.mjs
+++ b/src/lustre/vdom/reconciler.ffi.mjs
@@ -594,6 +594,7 @@ const createServerEvent = (event, include = []) => {
 
 // ATTRIBUTE SPECIAL CASES -----------------------------------------------------
 
+/* @__NO_SIDE_EFFECTS__ */
 const syncedBooleanAttribute = (name) => {
   return {
     added(node) {
@@ -605,6 +606,7 @@ const syncedBooleanAttribute = (name) => {
   };
 };
 
+/* @__NO_SIDE_EFFECTS__ */
 const syncedAttribute = (name) => {
   return {
     added(node, value) {


### PR DESCRIPTION
If the function is defined inside the class, the property access while exporting it as a function is treated as a possible side effect, forcing the entirety of lustre to be included in the bundle as soon as the `lustre` module is imported.

I also adde _no side effects_ annotations to the attribute hook higher-order functions. this makes it possible for esbuild to remove the `SYNCED_ATTRIBUTE` constant if it's not used.