### PR TITLE
🔀 Update guide to use mist v5

### DIFF
--- a/pages/guide/06-full-stack-applications.md
+++ b/pages/guide/06-full-stack-applications.md
@@ -335,7 +335,7 @@ pub fn main() {
     |> wisp_mist.handler(secret_key_base)
     |> mist.new
     |> mist.port(3000)
-    |> mist.start_http
+    |> mist.start
 
   process.sleep_forever()
 }


### PR DESCRIPTION
Mist 5.0.0 replaced `mist.start_http` by `mist.start`

cf. https://github.com/rawhat/mist/commit/95ecb398bef8676206ae9f131be8e0c2a74aa6d6