### PR TITLE
:zap: remove dict/set/isEqual dependencies from the javascript SPA builds

### DIFF
--- a/src/lustre/component.gleam
+++ b/src/lustre/component.gleam
@@ -35,7 +35,7 @@
 
 // IMPORTS ---------------------------------------------------------------------
 
-import gleam/dict.{type Dict}
+import gleam/dict
 import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode.{type Decoder}
 import gleam/list
@@ -61,8 +61,8 @@ pub opaque type Config(msg) {
     open_shadow_root: Bool,
     adopt_styles: Bool,
     //
-    attributes: Dict(String, fn(String) -> Result(msg, Nil)),
-    properties: Dict(String, Decoder(msg)),
+    attributes: List(#(String, fn(String) -> Result(msg, Nil))),
+    properties: List(#(String, Decoder(msg))),
     //
     is_form_associated: Bool,
     on_form_autofill: option.Option(fn(String) -> msg),
@@ -135,8 +135,8 @@ pub fn new(options: List(Option(msg))) -> Config(msg) {
       open_shadow_root: False,
       adopt_styles: True,
       //
-      attributes: constants.empty_dict(),
-      properties: constants.empty_dict(),
+      attributes: constants.empty_list,
+      properties: constants.empty_list,
       //
       is_form_associated: False,
       on_form_autofill: constants.option_none,
@@ -165,7 +165,7 @@ pub fn on_attribute_change(
   decoder: fn(String) -> Result(msg, Nil),
 ) -> Option(msg) {
   use config <- Option
-  let attributes = dict.insert(config.attributes, name, decoder)
+  let attributes = [#(name, decoder), ..config.attributes]
 
   Config(..config, attributes:)
 }
@@ -180,7 +180,7 @@ pub fn on_attribute_change(
 ///
 pub fn on_property_change(name: String, decoder: Decoder(msg)) -> Option(msg) {
   use config <- Option
-  let properties = dict.insert(config.properties, name, decoder)
+  let properties = [#(name, decoder), ..config.properties]
 
   Config(..config, properties:)
 }
@@ -289,9 +289,9 @@ pub fn to_server_component_config(config: Config(msg)) -> runtime.Config(msg) {
   runtime.Config(
     open_shadow_root: config.open_shadow_root,
     adopt_styles: config.adopt_styles,
-    //
-    attributes: config.attributes,
-    properties: config.properties,
+    // we reverse both lists here such that the last added value takes precedence
+    attributes: dict.from_list(list.reverse(config.attributes)),
+    properties: dict.from_list(list.reverse(config.properties)),
   )
 }
 

--- a/src/lustre/internals/mutable_map.ffi.mjs
+++ b/src/lustre/internals/mutable_map.ffi.mjs
@@ -24,6 +24,10 @@ export function get(map, key) {
   }
 }
 
+export function has_key(map, key) {
+  return map && map.has(key)
+}
+
 export function insert(map, key, value) {
   map ??= new Map();
   map.set(key, value);
@@ -40,3 +44,4 @@ export function remove(map, key) {
 export function size(map) {
   return map?.size ?? 0;
 }
+

--- a/src/lustre/internals/mutable_map.gleam
+++ b/src/lustre/internals/mutable_map.gleam
@@ -28,6 +28,12 @@ pub fn get(map: MutableMap(key, value), key: key) -> Result(value, Nil)
 
 ///
 ///
+@external(erlang, "gleam@dict", "has_key")
+@external(javascript, "./mutable_map.ffi.mjs", "has_key")
+pub fn has_key(map: MutableMap(key, value), key: key) -> Bool
+
+///
+///
 @external(erlang, "gleam@dict", "insert")
 @external(javascript, "./mutable_map.ffi.mjs", "insert")
 pub fn insert(

--- a/src/lustre/runtime/server/runtime.ffi.mjs
+++ b/src/lustre/runtime/server/runtime.ffi.mjs
@@ -32,7 +32,7 @@ export class Runtime {
   #vdom;
   #events;
 
-  #callbacks = new Set();
+  #callbacks = /* @__PURE__ */ new Set();
 
   constructor([model, effects], view, update, on_attribute_change) {
     this.#model = model;


### PR DESCRIPTION
Reduces the size of the `Hello World` example app from 13k min+gzip to 9.8 min+gzip or 9.3kb using zstandard compression.