### PR TITLE
🐛 Update example to reflect cat count changes

### DIFF
--- a/pages/guide/01-quickstart.md
+++ b/pages/guide/01-quickstart.md
@@ -353,7 +353,7 @@ fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     )
 
     UserClickedRemoveCat -> #(
-      Model(..model, cats: list.drop(model.cats, 1)),
+      Model(total: model.total - 1, cats: list.drop(model.cats, 1)),
       effect.none()
     )
 


### PR DESCRIPTION
Hi! I am learning Gleam and are going through the Lustre docs to learn more about the MVU architecture it offers, and stumbled upon this minor behavior discrepancy when syncing the total count and the cats pics. Feel free to take a look, ty!