### PR TITLE
:memo: add publish-subscribe example

### DIFF
--- a/examples/06-server-components/05-publish-subscribe/README.md
+++ b/examples/06-server-components/05-publish-subscribe/README.md
@@ -1,0 +1,1 @@
+# 06-server-components/05-publish-subscribe

--- a/examples/06-server-components/05-publish-subscribe/gleam.toml
+++ b/examples/06-server-components/05-publish-subscribe/gleam.toml
@@ -9,4 +9,4 @@ gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.60.0 and < 2.0.0"
 lustre = { path = "../../../" }
 mist = ">= 5.0.0 and < 6.0.0"
-glubsub = ">= 1.2.0 and < 2.0.0"
+group_registry = ">= 1.0.0 and < 2.0.0"

--- a/examples/06-server-components/05-publish-subscribe/gleam.toml
+++ b/examples/06-server-components/05-publish-subscribe/gleam.toml
@@ -1,0 +1,12 @@
+name = "app"
+version = "1.0.0"
+
+[dependencies]
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
+gleam_http = ">= 3.7.2 and < 5.0.0"
+gleam_json = ">= 2.3.0 and < 4.0.0"
+gleam_otp = ">= 1.0.0 and < 2.0.0"
+gleam_stdlib = ">= 0.60.0 and < 2.0.0"
+lustre = { path = "../../../" }
+mist = ">= 5.0.0 and < 6.0.0"
+glubsub = ">= 1.2.0 and < 2.0.0"

--- a/examples/06-server-components/05-publish-subscribe/src/app.gleam
+++ b/examples/06-server-components/05-publish-subscribe/src/app.gleam
@@ -1,0 +1,184 @@
+// IMPORTS ---------------------------------------------------------------------
+
+import gleam/bytes_tree
+import gleam/erlang/application
+import gleam/erlang/process.{type Selector, type Subject}
+import gleam/http/request.{type Request}
+import gleam/http/response.{type Response}
+import gleam/json
+import gleam/option.{type Option, None, Some}
+import glubsub
+import lustre
+import lustre/attribute
+import lustre/element
+import lustre/element/html.{html}
+import lustre/server_component
+import mist.{type Connection, type ResponseData}
+import whiteboard
+
+// MAIN ------------------------------------------------------------------------
+
+pub fn main() {
+  // In this example, we'll use the `glubsub` library to add a publish-subscribe
+  // mechanism to our whiteboard from the previous example.
+  //
+  // Every client will start its own instance of our whiteboard server component,
+  // and it will use glubsub to communicate to other instances.
+  //
+  // Using glubsub, we first have to create a "topic" that we can send messages
+  // and subscribe to. The topic is shared between all instances, so we create
+  // it at the start of our app.
+  let assert Ok(topic) = glubsub.new_topic()
+
+  let assert Ok(_) =
+    fn(request: Request(Connection)) -> Response(ResponseData) {
+      case request.path_segments(request) {
+        [] -> serve_html()
+        ["lustre", "runtime.mjs"] -> serve_runtime()
+        ["ws"] -> serve_whiteboard(request, topic)
+        _ -> response.set_body(response.new(404), mist.Bytes(bytes_tree.new()))
+      }
+    }
+    |> mist.new
+    |> mist.bind("localhost")
+    |> mist.port(1234)
+    |> mist.start
+
+  process.sleep_forever()
+}
+
+// HTML ------------------------------------------------------------------------
+
+fn serve_html() -> Response(ResponseData) {
+  let html =
+    html([attribute.lang("en")], [
+      html.head([], [
+        html.meta([attribute.charset("utf-8")]),
+        html.meta([
+          attribute.name("viewport"),
+          attribute.content("width=device-width, initial-scale=1"),
+        ]),
+        html.title([], "06-server-components/05-publish-subscribe"),
+        html.script(
+          [attribute.type_("module"), attribute.src("/lustre/runtime.mjs")],
+          "",
+        ),
+      ]),
+      html.body([attribute.style("height", "100dvh")], [
+        server_component.element([server_component.route("/ws")], []),
+      ]),
+    ])
+    |> element.to_document_string_tree
+    |> bytes_tree.from_string_tree
+
+  response.new(200)
+  |> response.set_body(mist.Bytes(html))
+  |> response.set_header("content-type", "text/html")
+}
+
+// JAVASCRIPT ------------------------------------------------------------------
+
+fn serve_runtime() -> Response(ResponseData) {
+  let assert Ok(lustre_priv) = application.priv_directory("lustre")
+  let file_path = lustre_priv <> "/static/lustre-server-component.min.mjs"
+
+  case mist.send_file(file_path, offset: 0, limit: None) {
+    Ok(file) ->
+      response.new(200)
+      |> response.prepend_header("content-type", "application/javascript")
+      |> response.set_body(file)
+
+    Error(_) ->
+      response.new(404)
+      |> response.set_body(mist.Bytes(bytes_tree.new()))
+  }
+}
+
+// WEBSOCKET -------------------------------------------------------------------
+
+fn serve_whiteboard(
+  request: Request(Connection),
+  topic: glubsub.Topic(whiteboard.SharedMsg),
+) -> Response(ResponseData) {
+  mist.websocket(
+    request:,
+    on_init: init_whiteboard_socket(_, topic),
+    handler: loop_whiteboard_socket,
+    on_close: close_whiteboard_socket,
+  )
+}
+
+type WhiteboardSocket {
+  WhiteboardSocket(
+    component: lustre.Runtime(whiteboard.Msg),
+    self: Subject(server_component.ClientMessage(whiteboard.Msg)),
+  )
+}
+
+type WhiteboardSocketMessage =
+  server_component.ClientMessage(whiteboard.Msg)
+
+type WhiteboardSocketInit =
+  #(WhiteboardSocket, Option(Selector(WhiteboardSocketMessage)))
+
+fn init_whiteboard_socket(
+  _socket: mist.WebsocketConnection,
+  topic: glubsub.Topic(whiteboard.SharedMsg),
+) -> WhiteboardSocketInit {
+  // compared to the "multiple clients" example, we start a new server
+  // component for each client, passing the topic we created to its
+  // `init` function.
+  //
+  // This topic is then used in the whitespace component to communicate with
+  // other component instances.
+  let whiteboard = whiteboard.component()
+  let assert Ok(component) = lustre.start_server_component(whiteboard, topic)
+
+  let self = process.new_subject()
+  let selector = process.new_selector() |> process.select(self)
+
+  server_component.register_subject(self)
+  |> lustre.send(to: component)
+
+  #(WhiteboardSocket(component:, self:), Some(selector))
+}
+
+fn loop_whiteboard_socket(
+  state: WhiteboardSocket,
+  message: mist.WebsocketMessage(WhiteboardSocketMessage),
+  connection: mist.WebsocketConnection,
+) -> mist.Next(WhiteboardSocket, WhiteboardSocketMessage) {
+  case message {
+    mist.Text(json) -> {
+      case json.parse(json, server_component.runtime_message_decoder()) {
+        Ok(runtime_message) -> lustre.send(state.component, runtime_message)
+        Error(_) -> Nil
+      }
+
+      mist.continue(state)
+    }
+
+    mist.Binary(_) -> {
+      mist.continue(state)
+    }
+
+    mist.Custom(client_message) -> {
+      let json = server_component.client_message_to_json(client_message)
+      let assert Ok(_) = mist.send_text_frame(connection, json.to_string(json))
+
+      mist.continue(state)
+    }
+
+    mist.Closed | mist.Shutdown -> {
+      server_component.deregister_subject(state.self)
+      |> lustre.send(to: state.component)
+
+      mist.stop()
+    }
+  }
+}
+
+fn close_whiteboard_socket(state: WhiteboardSocket) -> Nil {
+  lustre.shutdown()
+  |> lustre.send(to: state.component)
+}

--- a/examples/06-server-components/05-publish-subscribe/src/app.gleam
+++ b/examples/06-server-components/05-publish-subscribe/src/app.gleam
@@ -22,11 +22,11 @@ pub fn main() {
   // In this example, we'll use the `glubsub` library to add a publish-subscribe
   // mechanism to our whiteboard from the previous example.
   //
-  // Every client will start its own instance of our whiteboard server component,
-  // and it will use glubsub to communicate to other instances.
+  // Every client will start its own instance of the whiteboard server component,
+  // and will use a glubsub topic to communicate with the other instances.
   //
   // Using glubsub, we first have to create a "topic" that we can send messages
-  // and subscribe to. The topic is shared between all instances, so we create
+  // and subscribe to. The topic is shared between all clients, so we create
   // it at the start of our app.
   let assert Ok(topic) = glubsub.new_topic()
 
@@ -125,12 +125,12 @@ fn init_whiteboard_socket(
   _socket: mist.WebsocketConnection,
   topic: glubsub.Topic(whiteboard.SharedMsg),
 ) -> WhiteboardSocketInit {
-  // compared to the "multiple clients" example, we start a new server
-  // component for each client, passing the topic we created to its
+  // Compared to the "multiple clients" example, we start a new server
+  // component instance for each client, passing the topic we created to its
   // `init` function.
   //
-  // This topic is then used in the whitespace component to communicate with
-  // other component instances.
+  // This topic can then used in the whitespace component to communicate with
+  // other component instances. Check out the whitespace component to learn how!
   let whiteboard = whiteboard.component()
   let assert Ok(component) = lustre.start_server_component(whiteboard, topic)
 

--- a/examples/06-server-components/05-publish-subscribe/src/whiteboard.gleam
+++ b/examples/06-server-components/05-publish-subscribe/src/whiteboard.gleam
@@ -1,0 +1,271 @@
+// IMPORTS ---------------------------------------------------------------------
+
+import gleam/dict.{type Dict}
+import gleam/dynamic/decode
+import gleam/erlang/process
+import gleam/int
+import glubsub
+import lustre.{type App}
+import lustre/attribute.{attribute}
+import lustre/effect.{type Effect}
+import lustre/element.{type Element}
+import lustre/element/html
+import lustre/element/svg
+import lustre/event
+import lustre/server_component
+
+// MAIN ------------------------------------------------------------------------
+
+pub fn component() -> App(glubsub.Topic(SharedMsg), Model, Msg) {
+  lustre.application(init, update, view)
+}
+
+// MODEL -----------------------------------------------------------------------
+
+pub type Color {
+  Blue
+  Red
+  Green
+  Yellow
+}
+
+fn to_string(color: Color) -> String {
+  case color {
+    Red -> "red"
+    Blue -> "blue"
+    Green -> "green"
+    Yellow -> "yellow"
+  }
+}
+
+pub type Model {
+  Model(
+    drawn_points: Dict(#(Int, Int), Color),
+    selected_color: Color,
+    topic: glubsub.Topic(SharedMsg),
+  )
+}
+
+fn init(topic: glubsub.Topic(SharedMsg)) -> #(Model, Effect(Msg)) {
+  let model = Model(drawn_points: dict.new(), selected_color: Red, topic: topic)
+
+  // When the main app starts our server component, it passes us a glubsub topic
+  // that we can use to communicate with other instances of the whiteboard.
+  //
+  // On init, we want to subscribe to this topic to make sure we know what's
+  // going on!
+  //
+  // Note: We do not have to unsubscribe! glubsub will monitor our server
+  // component actor and will automatically unsubscribe us once it shuts down.
+  //
+  // Note: This still does not make a complete whiteboard app! Try drawing with
+  // the first client before connecting the second one.
+  #(model, subscribe(topic, AppReceivedSharedMsg))
+}
+
+fn subscribe(
+  topic: glubsub.Topic(topic),
+  on_msg handle_msg: fn(topic) -> msg,
+) -> Effect(msg) {
+  // Using the special `select` effect, we get a fresh new subject that we can
+  // use to subscribe to glubsub.
+  use _dispatch, subject <- server_component.select
+
+  let assert Ok(_) = glubsub.subscribe(topic, subject)
+
+  // We need to teach Lustres runtime how to listen for messages on this subject,
+  // by returning Selector that matches our apps `Msg` type.
+  let selector =
+    process.new_selector()
+    |> process.select_map(subject, handle_msg)
+
+  selector
+}
+
+// UPDATE ----------------------------------------------------------------------
+
+/// We have 2 kinds of messages:
+/// 
+/// - Messages that originate from this instance of the server-component
+/// - Messages that we receive and send from the glubsub topic.
+///
+/// `SharedMsg` contains messages of the latter type.
+pub opaque type SharedMsg {
+  /// Any client wnats to draw something on the whiteboard.
+  ClientDrewCircle(x: Int, y: Int, color: Color)
+  /// Any client wants to clear the screen.
+  ClientClearedScreen
+}
+
+/// `Msg` is the usual message type in a Lustre app and contains all messages
+/// that a single instance of our server component can receive.
+pub opaque type Msg {
+  /// We received some SharedMsg from the glubsub topic.
+  AppReceivedSharedMsg(msg: SharedMsg)
+  /// The selected color can be different for every single client.
+  UserChangedColor(color: Color)
+  /// We have a way to get notified if some client wants to modify the pixels
+  /// through the shared topic, but we still a way for the user to tell us that
+  /// they want to in the first place!
+  UserDrewCircle(x: Int, y: Int, color: Color)
+  ///
+  UserClearedScreen
+}
+
+fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
+  case msg {
+    AppReceivedSharedMsg(ClientDrewCircle(x:, y:, color:)) -> {
+      // If any client wants to draw on the screen, we do that update locally
+      // to reflect that change.
+      //
+      // Note: This means that we duplicate this state in every client and that
+      // it can get out-of-sync if a client is not subscribed for the entire
+      // time! (for example if they join later)
+      let new_points =
+        model.drawn_points
+        |> dict.insert(#(x, y), color)
+
+      #(Model(..model, drawn_points: new_points), effect.none())
+    }
+
+    AppReceivedSharedMsg(ClientClearedScreen) -> {
+      let model = Model(..model, drawn_points: dict.new())
+
+      #(model, effect.none())
+    }
+
+    UserChangedColor(color:) -> {
+      #(Model(..model, selected_color: color), effect.none())
+    }
+
+    UserDrewCircle(x:, y:, color:) -> {
+      // If a user wants to draw, instead of doing that directly we broadcast
+      // that intent as a SharedMsg over our topic.
+      // Later, we will receive that same message ourselves, at which point we
+      // will update the pixels.
+      #(model, broadcast(model.topic, ClientDrewCircle(x:, y:, color:)))
+    }
+
+    UserClearedScreen -> {
+      #(model, broadcast(model.topic, ClientClearedScreen))
+    }
+  }
+}
+
+fn broadcast(channel: glubsub.Topic(msg), msg: msg) -> Effect(any) {
+  use _dispatch <- effect.from
+  let assert Ok(_) = glubsub.broadcast(channel, msg)
+  Nil
+}
+
+// VIEW ------------------------------------------------------------------------
+
+fn view(model: Model) -> Element(Msg) {
+  let on_mouse_move =
+    event.on("mousemove", {
+      use button <- decode.field("buttons", decode.int)
+      use client_x <- decode.field("clientX", decode.int)
+      use client_y <- decode.field("clientY", decode.int)
+
+      case button {
+        1 ->
+          decode.success(UserDrewCircle(
+            x: client_x,
+            y: client_y,
+            color: model.selected_color,
+          ))
+        _ -> decode.failure(UserDrewCircle(x: 0, y: 0, color: Red), "Msg")
+      }
+    })
+    |> server_component.include(["buttons", "clientX", "clientY"])
+    |> event.throttle(5)
+
+  element.fragment([
+    html.style([], {
+      "
+      #controls {
+        align-items: center;
+        background-color: white;
+        border-radius: 2rem;
+        box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+        display: flex;
+        gap: 1rem;
+        left: 1rem;
+        padding: 1rem 1.5rem;
+        position: fixed;
+        bottom: 1rem;
+        z-index: 1;
+        width: max-content;
+
+        .colour {
+          border: none;
+          width: 3rem;
+          height: 3rem;
+          border-radius: 50%;
+          display: inline-block;
+        }
+
+        .colour.selected {
+          filter: darken(0.2);
+        }
+      }
+
+      svg {
+        background-color: oklch(98.4% 0.003 247.858);
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+      }
+      "
+    }),
+    html.div([attribute.id("controls")], [
+      html.button(
+        [
+          attribute.class("colour"),
+          attribute.style("background-color", "red"),
+          event.on_click(UserChangedColor(Red)),
+        ],
+        [],
+      ),
+      html.button(
+        [
+          attribute.class("colour selected"),
+          attribute.style("background-color", "green"),
+          event.on_click(UserChangedColor(Green)),
+        ],
+        [],
+      ),
+      html.button(
+        [
+          attribute.class("colour"),
+          attribute.style("background-color", "blue"),
+          event.on_click(UserChangedColor(Blue)),
+        ],
+        [],
+      ),
+      html.button(
+        [
+          attribute.class("colour"),
+          attribute.style("background-color", "yellow"),
+          event.on_click(UserChangedColor(Yellow)),
+        ],
+        [],
+      ),
+      html.button([event.on_click(UserClearedScreen)], [html.text("Clear")]),
+    ]),
+    html.svg([on_mouse_move], {
+      use points, #(x, y), color <- dict.fold(model.drawn_points, [])
+      let point =
+        svg.circle([
+          attribute("cx", int.to_string(x)),
+          attribute("cy", int.to_string(y)),
+          attribute("r", "5"),
+          attribute("fill", to_string(color)),
+        ])
+
+      [point, ..points]
+    }),
+  ])
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -114,8 +114,8 @@ examples demonstrate Lustre's _server components_.
   demonstrates how to include events in server components.
 
 - [`04-multiple-clients`](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/04-multiple-clients)
-  shows how to handle multiple connected clients with server components.
- 
+  shows how to handle multiple clients connected to the same server component runtime.
+
 - [`5-publish-subscribe`](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/05-publish-subscribe)
   shows how to handle multiple individual clients using a publish-subscribe to communicate.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -114,7 +114,10 @@ examples demonstrate Lustre's _server components_.
   demonstrates how to include events in server components.
 
 - [`04-multiple-clients`](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/04-multiple-clients)
-  shows how to handle multiple clients with server components.
+  shows how to handle multiple connected clients with server components.
+ 
+- [`5-publish-subscribe`](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/05-publish-subscribe)
+  shows how to handle multiple individual clients using a publish-subscribe to communicate.
 
 ## Getting help
 

--- a/pages/reference/examples.md
+++ b/pages/reference/examples.md
@@ -114,7 +114,10 @@ examples demonstrate Lustre's _server components_.
   demonstrates how to include events in server components.
 
 - [`04-multiple-clients`](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/04-multiple-clients)
-  shows how to handle multiple clients with server components.
+  shows how to handle multiple connected clients with server components.
+
+- [`5-publish-subscribe`](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/05-publish-subscribe)
+  shows how to handle multiple individual clients using a publish-subscribe to communicate.
 
 ## Getting help
 

--- a/pages/reference/examples.md
+++ b/pages/reference/examples.md
@@ -117,7 +117,7 @@ examples demonstrate Lustre's _server components_.
   shows how to handle multiple clients connected to the same server component runtime.
 
 - [`5-publish-subscribe`](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/05-publish-subscribe)
-  shows how to handle multiple individual clients using a publish-subscribe to communicate.
+  shows how to handle multiple server components using publish-subscribe to communicate.
 
 ## Getting help
 

--- a/pages/reference/examples.md
+++ b/pages/reference/examples.md
@@ -114,7 +114,7 @@ examples demonstrate Lustre's _server components_.
   demonstrates how to include events in server components.
 
 - [`04-multiple-clients`](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/04-multiple-clients)
-  shows how to handle multiple connected clients with server components.
+  shows how to handle multiple clients connected to the same server component runtime.
 
 - [`5-publish-subscribe`](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/05-publish-subscribe)
   shows how to handle multiple individual clients using a publish-subscribe to communicate.

--- a/src/lustre/server_component.gleam
+++ b/src/lustre/server_component.gleam
@@ -66,6 +66,8 @@
 ////
 //// - [Connecting more than one client](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/04-multiple-clients)
 ////
+//// - [Adding publish-subscribe](https://github.com/lustre-labs/lustre/tree/main/examples/06-server-components/05-publish-subscribe)
+////
 //// ## Getting help
 ////
 //// If you're having trouble with Lustre or not sure what the right way to do


### PR DESCRIPTION
uses [glubsub](https://github.com/okkdev/glubsub) to add a simple publish-subscribe mechanism to the whiteboard example.

closes #287, closes #297