### PR TITLE
:bug: fix server-component fragment advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ request to fix it.
 - [lustre/element] Fixed a bug where a top-level fragment would not be hydrated correctly.
 - [lustre/element/keyed] Fixed a bug where keyed elements were not virtualised correctly.
 - [lustre/server_component] Fixed a bug where empty `value` attributes would result in a value of `undefined`
+- [lustre/server_component] Fixed a bug where events inside fragments would not work.
 
 ## [v5.2.1] - 2025-06-23
 

--- a/src/lustre/vdom/reconciler.ffi.mjs
+++ b/src/lustre/vdom/reconciler.ffi.mjs
@@ -1,7 +1,6 @@
 // IMPORTS ---------------------------------------------------------------------
 
 import {
-  advance,
   element_kind,
   text_kind,
   fragment_kind,
@@ -448,6 +447,10 @@ const iterate = (list, callback) => {
     }
   }
 };
+
+const advance = (vnode) => {
+  return 1 + (vnode.children_count|0);
+}
 
 const appendChild = (node, child) => node.appendChild(child);
 const insertBefore = (parent, node, referenceNode) =>


### PR DESCRIPTION
The `advance` function from vnode would not work because it uses an instanceof check. This will be fixed anyways when I finish the reconciler rewrite but I thought documenting it would be nice too :3

