### PR TITLE
🔀 Update forms example to be compatible with latest `formal` API changes

### DIFF
--- a/examples/02-inputs/04-forms/gleam.toml
+++ b/examples/02-inputs/04-forms/gleam.toml
@@ -5,4 +5,4 @@ dev-dependencies = { lustre_dev_tools = ">= 1.6.5 and < 2.0.0" }
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 lustre = { path = "../../../" }
-formal = ">= 2.2.0 and < 3.0.0"
+formal = ">= 3.0.0 and < 4.0.0"


### PR DESCRIPTION
Hi!
`formal` 3.0.0 got released with API breaking changes.
I updated the relevant example file to be compatible with this new version. 

Another option would be to copy formal’s own up to date lustre example from [here](https://github.com/lpil/formal/tree/main/examples/frontend-with-lustre), so that it is easy to keep it in sync in the future.

