### PR TITLE
Optional messages for advanced events

### DIFF
--- a/examples/02-inputs/05-advanced-events/README.md
+++ b/examples/02-inputs/05-advanced-events/README.md
@@ -1,0 +1,1 @@
+# 02-inputs/05-advanced-events

--- a/examples/02-inputs/05-advanced-events/gleam.toml
+++ b/examples/02-inputs/05-advanced-events/gleam.toml
@@ -1,0 +1,7 @@
+name = "app"
+version = "1.0.0"
+dev-dependencies = { lustre_dev_tools = ">= 1.6.5 and < 2.0.0" }
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+lustre = { path = "../../../" }

--- a/examples/02-inputs/05-advanced-events/index.html
+++ b/examples/02-inputs/05-advanced-events/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <title>02-inputs/01-controlled-inputs</title>
+
+        <link rel="stylesheet" href="/priv/static/app.css" />
+        <script type="module" src="/priv/static/app.mjs"></script>
+    </head>
+
+    <body>
+        <div id="app"></div>
+    </body>
+</html>

--- a/examples/02-inputs/05-advanced-events/src/app.css
+++ b/examples/02-inputs/05-advanced-events/src/app.css
@@ -1,0 +1,1 @@
+@import "tailwindcss"

--- a/examples/02-inputs/05-advanced-events/src/app.gleam
+++ b/examples/02-inputs/05-advanced-events/src/app.gleam
@@ -1,0 +1,102 @@
+// IMPORTS ---------------------------------------------------------------------
+
+import gleam/dynamic/decode
+import gleam/io
+import gleam/string
+import lustre
+import lustre/attribute
+import lustre/element.{type Element}
+import lustre/element/html
+import lustre/event
+
+// MAIN ------------------------------------------------------------------------
+
+pub fn main() {
+  let app = lustre.simple(init, update, view)
+  let assert Ok(_) = lustre.start(app, "#app", Nil)
+
+  Nil
+}
+
+// MODEL -----------------------------------------------------------------------
+
+type Model =
+  String
+
+fn init(_) -> Model {
+  "Lucy"
+}
+
+// UPDATE ----------------------------------------------------------------------
+
+type Msg {
+  UserUpdatedName(String)
+  OnKeyDown(String)
+}
+
+fn update(model: Model, msg: Msg) -> Model {
+  case msg {
+    UserUpdatedName(name) ->
+      case string.length(name) <= 10 {
+        True -> name
+        // If we don't update the state of a controlled input, then it won't
+        // change in the DOM even though the input is still receiving keyboard
+        // events.
+        False -> model
+      }
+    OnKeyDown(key) -> {
+      case key {
+        "a" -> io.println("Correct this should have been called (twice)!!")
+        _else -> io.println("This should not have been called!!")
+      }
+
+      model
+    }
+  }
+}
+
+// VIEW ------------------------------------------------------------------------
+
+fn view(model: Model) -> Element(Msg) {
+  let on_keydown = {
+    use key <- decode.field("key", decode.string)
+
+    case key {
+      "a" ->
+        event.send(
+          dispatch: OnKeyDown("a"),
+          prevent_default: False,
+          stop_propagation: False,
+        )
+      _ -> event.retain(prevent_default: False, stop_propagation: True)
+    }
+  }
+
+  html.div(
+    [
+      attribute.class("p-32 mx-auto w-full max-w-2xl space-y-4"),
+      // Standard on keydown
+      event.on_keydown(OnKeyDown),
+    ],
+    [
+      html.label([attribute.class("flex gap-2")], [
+        html.span([], [html.text("Enter a name: ")]),
+        html.input([
+          attribute.value(model),
+          event.on_input(UserUpdatedName),
+          // Advanced on keydown
+          event.advanced("keydown", on_keydown),
+          attribute.class("border border-slate-400 px-1 rounded"),
+          attribute.class("focus:outline-none focus:border-blue-500"),
+        ]),
+      ]),
+      html.p([], [
+        html.text("Hello there, "),
+        // As we type, the value stored in the model is updated on every keystroke
+        // and reflected here.
+        html.text(model),
+        html.text("!"),
+      ]),
+    ],
+  )
+}

--- a/examples/02-inputs/05-advanced-events/tailwind.config.js
+++ b/examples/02-inputs/05-advanced-events/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{gleam,mjs}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/src/lustre/dev/simulate.gleam
+++ b/src/lustre/dev/simulate.gleam
@@ -11,6 +11,7 @@ import lustre/effect.{type Effect}
 import lustre/element.{type Element}
 import lustre/vdom/events
 import lustre/vdom/path
+import lustre/vdom/vattr
 
 // TYPES -----------------------------------------------------------------------
 
@@ -222,7 +223,12 @@ pub fn event(
       ),
     ))
 
-    let #(model, _) = simulation.update(simulation.model, handler.message)
+    let model = case handler.message {
+      vattr.Message(message) ->
+        simulation.update(simulation.model, message) |> pair.first
+      vattr.Messageless -> simulation.model
+    }
+
     let html = simulation.view(model)
     let history = [
       Event(target: query, name: event, data:),

--- a/src/lustre/event.gleam
+++ b/src/lustre/event.gleam
@@ -50,7 +50,11 @@ pub fn on(name: String, handler: Decoder(msg)) -> Attribute(msg) {
   vattr.event(
     name:,
     handler: decode.map(handler, fn(msg) {
-      Handler(prevent_default: False, stop_propagation: False, message: msg)
+      Handler(
+        prevent_default: False,
+        stop_propagation: False,
+        message: vattr.Message(msg),
+      )
     }),
     include: constants.empty_list,
     prevent_default: vattr.never,
@@ -91,12 +95,31 @@ pub fn advanced(name: String, handler: Decoder(Handler(msg))) -> Attribute(msg) 
 /// Construct a [`Handler`](#Handler) that can be used with [`advanced`](#advanced)
 /// to conditionally stop propagation or prevent the default behaviour of an event.
 ///
-pub fn handler(
+fn handler(
+  message: vattr.MessageBody(msg),
+  prevent_default: Bool,
+  stop_propagation: Bool,
+) -> Handler(msg) {
+  Handler(prevent_default:, stop_propagation:, message:)
+}
+
+pub fn send(
   dispatch message: msg,
   prevent_default prevent_default: Bool,
   stop_propagation stop_propagation: Bool,
-) -> Handler(msg) {
-  Handler(prevent_default:, stop_propagation:, message:)
+) {
+  vattr.Message(message)
+  |> handler(prevent_default, stop_propagation)
+  |> decode.success
+}
+
+pub fn retain(
+  prevent_default prevent_default: Bool,
+  stop_propagation stop_propagation: Bool,
+) {
+  vattr.Messageless
+  |> handler(prevent_default, stop_propagation)
+  |> decode.success
 }
 
 fn is_immediate_event(name: String) -> Bool {

--- a/src/lustre/runtime/client/runtime.ffi.mjs
+++ b/src/lustre/runtime/client/runtime.ffi.mjs
@@ -2,8 +2,10 @@
 
 import { NonEmpty, Empty } from "../../../gleam.mjs";
 import * as $list from "../../../../gleam_stdlib/gleam/list.mjs";
+import { None } from "../../../../gleam_stdlib/gleam/option.mjs";
 import { empty_list } from "../../internals/constants.mjs";
 import { diff } from "../../vdom/diff.mjs";
+import { Message } from "../../vdom/vattr.mjs";
 import * as Events from "../../vdom/events.mjs";
 import { Reconciler } from "../../vdom/reconciler.ffi.mjs";
 import { virtualise } from "../../vdom/virtualise.ffi.mjs";
@@ -30,8 +32,6 @@ export const throw_server_component_error = () => {
     ].join(""),
   );
 };
-
-//
 
 export class Runtime {
   constructor(root, [model, effects], view, update) {
@@ -76,7 +76,9 @@ export class Runtime {
         if (handler.stop_propagation) event.stopPropagation();
         if (handler.prevent_default) event.preventDefault();
 
-        this.dispatch(handler.message, false);
+        if (handler.message instanceof Message) {
+          this.dispatch(Object.values(handler.message)[0], false);
+        }
       }
     });
 

--- a/src/lustre/vdom/diff.gleam
+++ b/src/lustre/vdom/diff.gleam
@@ -618,7 +618,7 @@ fn diff_attributes(
 
     [], [Event(name:, handler:, ..) as next, ..new] -> {
       let added = [next, ..added]
-      let events = events.add_event(events, mapper, path, name, handler)
+      let events = events.add_event(events, path, name, handler)
       diff_attributes(
         controlled:,
         path:,
@@ -709,7 +709,7 @@ fn diff_attributes(
             False -> added
           }
 
-          let events = events.add_event(events, mapper, path, name, handler)
+          let events = events.add_event(events, path, name, handler)
 
           diff_attributes(
             controlled:,
@@ -743,7 +743,7 @@ fn diff_attributes(
         _, Eq, Event(name:, handler:, ..) -> {
           let added = [next, ..added]
           let removed = [prev, ..removed]
-          let events = events.add_event(events, mapper, path, name, handler)
+          let events = events.add_event(events, path, name, handler)
 
           diff_attributes(
             controlled:,
@@ -775,7 +775,7 @@ fn diff_attributes(
 
         _, Gt, Event(name:, handler:, ..) -> {
           let added = [next, ..added]
-          let events = events.add_event(events, mapper, path, name, handler)
+          let events = events.add_event(events, path, name, handler)
 
           diff_attributes(
             controlled:,

--- a/src/lustre/vdom/vattr.gleam
+++ b/src/lustre/vdom/vattr.gleam
@@ -28,8 +28,17 @@ pub type Attribute(msg) {
   )
 }
 
+pub type MessageBody(msg) {
+  Message(msg)
+  Messageless
+}
+
 pub type Handler(msg) {
-  Handler(prevent_default: Bool, stop_propagation: Bool, message: msg)
+  Handler(
+    prevent_default: Bool,
+    stop_propagation: Bool,
+    message: MessageBody(msg),
+  )
 }
 
 pub type EventBehaviour {


### PR DESCRIPTION
this comes in handy when you need to stop a lot of events from propagating. Also improved the advanced API with `evend.send` and `event.retain` which helps reduce boilerplate. Think about a Dialogs component which needs to stop a lot of events from propagating. This also triggers a lot of necessary `lustre.view` calls.

Example: 

```gleam
let on_keydown = {
    use key <- decode.field("key", decode.string)

    case key {
      "a" ->
        event.send(
          dispatch: OnKeyDown("a"),
          prevent_default: False,
          stop_propagation: False,
        )
      _ -> event.retain(prevent_default: False, stop_propagation: True)
    }
  }
```