### PR TITLE
📝 Fix typos in examples

### DIFF
--- a/examples/02-inputs/02-decoding-events/src/app.gleam
+++ b/examples/02-inputs/02-decoding-events/src/app.gleam
@@ -55,7 +55,7 @@ fn view_xy_pad(
 ) -> Element(msg) {
   let on_mousemove =
     // Custom event handlers can be created using `event.on` and providing a
-    // deoder for the event object. In this case we have a `MouseEvent` which we
+    // decoder for the event object. In this case we have a `MouseEvent` which we
     // decode the x and y coordinates from.
     //
     // For other properties you could decode from this specific event, see the

--- a/examples/04-applications/04-hydration/src/app.gleam
+++ b/examples/04-applications/04-hydration/src/app.gleam
@@ -33,7 +33,7 @@ pub fn main() {
   //   by default for all apps and components.
   //
   // - Restore the apps `Model` to the state used to render the page on the
-  //   server. This is necesarry, since otherwise the Lustre client app would
+  //   server. This is necessary, since otherwise the Lustre client app would
   //   immediately override all differences with its values.
   //   Sending some values to the client runtime also means it doesn't have to
   //   fetch them again.

--- a/examples/05-components/01-basic-setup/src/counter.gleam
+++ b/examples/05-components/01-basic-setup/src/counter.gleam
@@ -30,7 +30,7 @@ pub fn element() -> Element(msg) {
 // MODEL -----------------------------------------------------------------------
 
 /// The state for our component will never leak outside the component itself.
-/// It's encpasulated the same way internal state for native HTML elements is.
+/// It's encapsulated the same way internal state for native HTML elements is.
 ///
 type Model =
   Int


### PR DESCRIPTION
Hi, fixes the very few typos I came across in the examples section