### PR TITLE
Add default_checked and default_selected attributes. 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+* text=auto
+
 test/integration/happy-dom.ffi.mjs linguist-vendored diff=generated

--- a/birdie_snapshots/[find]_hero_section_by_multiple_classes.accepted
+++ b/birdie_snapshots/[find]_hero_section_by_multiple_classes.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [find] Hero section by multiple classes
 file: ./test/snapshot/query_find_test.gleam
 test_name: find_element_by_multiple_classes_test

--- a/birdie_snapshots/[find_all]_all_sections_by_tag.accepted
+++ b/birdie_snapshots/[find_all]_all_sections_by_tag.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [find_all] All sections by tag
 file: ./test/snapshot/query_find_test.gleam
 test_name: find_all_by_tag_test

--- a/birdie_snapshots/[html]_default_checked_attribute_should_be_rendered_as_checked_attribute.accepted
+++ b/birdie_snapshots/[html]_default_checked_attribute_should_be_rendered_as_checked_attribute.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.3.1
+title: [html] Default checked attribute should be rendered as checked attribute
+---
+<input type="checkbox" checked>

--- a/birdie_snapshots/[html]_default_selected_attribute_should_be_rendered_as_selected_attribute.accepted
+++ b/birdie_snapshots/[html]_default_selected_attribute_should_be_rendered_as_selected_attribute.accepted
@@ -1,0 +1,9 @@
+---
+version: 1.3.1
+title: [html] Default selected attribute should be rendered as selected attribute
+---
+<select>
+  <option selected>
+
+  </option>
+</select>

--- a/birdie_snapshots/[html]_element_with_multiple_children_should_render_in_order.accepted
+++ b/birdie_snapshots/[html]_element_with_multiple_children_should_render_in_order.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.3
+version: 1.3.1
 title: [html] Element with multiple children should render in order
 ---
 <div>

--- a/birdie_snapshots/[html]_fragment_with_multiple_elements_should_render_on_multiple_lines.accepted
+++ b/birdie_snapshots/[html]_fragment_with_multiple_elements_should_render_on_multiple_lines.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [html] Fragment with multiple elements should render on multiple lines
 ---
 <div></div>

--- a/birdie_snapshots/[html]_fragment_with_multiple_mix_elements_should_render_on_multiple_lines.accepted
+++ b/birdie_snapshots/[html]_fragment_with_multiple_mix_elements_should_render_on_multiple_lines.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [html] Fragment with multiple mix elements should render on multiple lines
 ---
 Hello, 

--- a/birdie_snapshots/[html]_fragment_with_multiple_text_nodes_should_render_concatenated_text.accepted
+++ b/birdie_snapshots/[html]_fragment_with_multiple_text_nodes_should_render_concatenated_text.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [html] Fragment with multiple text nodes should render concatenated text
 ---
 Hello, world!

--- a/birdie_snapshots/[html]_fragment_with_single_element_should_render_that_element.accepted
+++ b/birdie_snapshots/[html]_fragment_with_single_element_should_render_that_element.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [html] Fragment with single element should render that element
 ---
 <div></div>

--- a/birdie_snapshots/[html]_fragment_with_single_text_node_should_render_plain_text.accepted
+++ b/birdie_snapshots/[html]_fragment_with_single_text_node_should_render_plain_text.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [html] Fragment with single text node should render plain text
 ---
 Hello, world!

--- a/birdie_snapshots/[html]_keyed_fragment_adds_keys_to_its_children.accepted
+++ b/birdie_snapshots/[html]_keyed_fragment_adds_keys_to_its_children.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [html] Keyed fragment adds keys to its children
 ---
 <div data-lustre-key="a">

--- a/birdie_snapshots/[html]_keyed_void_elements_should_render_as_such.accepted
+++ b/birdie_snapshots/[html]_keyed_void_elements_should_render_as_such.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [html] Keyed void elements should render as such
 ---
 <div>

--- a/birdie_snapshots/[html]_void_elements_should_render_as_such.accepted
+++ b/birdie_snapshots/[html]_void_elements_should_render_as_such.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.6
+version: 1.3.1
 title: [html] Void elements should render as such
 ---
 <div>

--- a/birdie_snapshots/[simulate]_missing_element.accepted
+++ b/birdie_snapshots/[simulate]_missing_element.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.7
+version: 1.3.1
 title: [simulate] Missing element
 file: ./test/integration/simulate_test.gleam
 test_name: simulate_missing_element_test

--- a/birdie_snapshots/[simulate]_missing_event_handler.accepted
+++ b/birdie_snapshots/[simulate]_missing_event_handler.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.2.7
+version: 1.3.1
 title: [simulate] Missing event handler
 file: ./test/integration/simulate_test.gleam
 test_name: simulate_missing_event_handler_test

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -796,8 +796,8 @@ pub fn checked(is_checked: Bool) -> Attribute(msg) {
   boolean_attribute("checked", is_checked)
 }
 
-/// Set the default checked state of a form control. This is the value that will
-/// be shown to users when the input is first rendered and included in the form
+/// Set the default checked state of a form control. This element will appear
+/// checked to users when the input is first rendered and its value will included in the form
 /// submission if the user does not change it.
 ///
 /// Just setting a default value and letting the DOM manage the state of an input

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -796,6 +796,19 @@ pub fn checked(is_checked: Bool) -> Attribute(msg) {
   boolean_attribute("checked", is_checked)
 }
 
+/// Set the default checked state of a form control. This is the value that will
+/// be shown to users when the input is first rendered and included in the form
+/// submission if the user does not change it.
+///
+/// Just setting a default value and letting the DOM manage the state of an input
+/// is known as using [_uncontrolled inputs](https://github.com/lustre-labs/lustre/blob/main/pages/hints/controlled-vs-uncontrolled-inputs.md).
+/// Doing this means your application cannot set the value of an input after it
+/// is modified without using an effect.
+///
+pub fn default_checked(is_checked: Bool) -> Attribute(msg) {
+  boolean_attribute("virtual:defaultChecked", is_checked)
+}
+
 /// The color space of the serialised CSS color. It also hints to user agents
 /// about what kind of interface to present to the user for selecting a color.
 /// The following values are accepted:
@@ -1102,6 +1115,20 @@ pub fn required(is_required: Bool) -> Attribute(msg) {
 ///
 pub fn selected(is_selected: Bool) -> Attribute(msg) {
   boolean_attribute("selected", is_selected)
+}
+
+/// An `<option>` with this attribute toggled on will be selected when 
+/// its corresponding select is rendered for the first time. Only one
+/// option can be selected at a time, unless the [`"multiple"`](#multiple)
+/// attribute is set on the select element.
+/// 
+/// Just setting a default value and letting the DOM manage the state of an input
+/// is known as using [_uncontrolled inputs](https://github.com/lustre-labs/lustre/blob/main/pages/hints/controlled-vs-uncontrolled-inputs.md).
+/// Doing this means your application cannot set the value of an input after it
+/// is modified without using an effect.
+///
+pub fn default_selected(is_selected: Bool) -> Attribute(msg) {
+  boolean_attribute("virtual:defaultSelected", is_selected)
 }
 
 /// Size of the control

--- a/src/lustre/vdom/reconciler.ffi.mjs
+++ b/src/lustre/vdom/reconciler.ffi.mjs
@@ -446,6 +446,12 @@ export class Reconciler {
         if (name === "virtual:defaultValue") {
           node.defaultValue = valueOrDefault;
           return;
+        } else if (name === "virtual:defaultChecked") {
+          node.defaultChecked = true 
+          return;
+        } else if (name === "virtual:defaultSelected") {
+          node.defaultSelected = true 
+          return;
         }
 
         if (valueOrDefault !== getAttribute(node, name)) {

--- a/src/lustre/vdom/vattr.gleam
+++ b/src/lustre/vdom/vattr.gleam
@@ -259,6 +259,12 @@ pub fn to_string_tree(
     Attribute(name: "virtual:defaultValue", value:, ..) ->
       string_tree.append(html, " value=\"" <> houdini.escape(value) <> "\"")
 
+    Attribute(name: "virtual:defaultChecked", ..) ->
+      string_tree.append(html, " checked")
+
+    Attribute(name: "virtual:defaultSelected", ..) ->
+      string_tree.append(html, " selected")
+
     Attribute(name: "", ..) -> html
     Attribute(name:, value: "", ..) -> string_tree.append(html, " " <> name)
     Attribute(name:, value:, ..) ->

--- a/test/snapshot/html_test.gleam
+++ b/test/snapshot/html_test.gleam
@@ -162,6 +162,33 @@ pub fn default_value_attribute_test() {
   |> snapshot("Default value attribute should be rendered as value attribute")
 }
 
+pub fn default_checked_attribute_test() {
+  use <- lustre_test.test_filter("default_checked_attribute_test")
+
+  let input =
+    html.input([
+      attribute.type_("checkbox"),
+      attribute.default_checked(True),
+    ])
+
+  input
+  |> snapshot(
+    "Default checked attribute should be rendered as checked attribute",
+  )
+}
+
+pub fn default_selected_attribute_test() {
+  use <- lustre_test.test_filter("default_selected_attribute_test")
+
+  let input =
+    html.select([], [html.option([attribute.default_selected(True)], "")])
+
+  input
+  |> snapshot(
+    "Default selected attribute should be rendered as selected attribute",
+  )
+}
+
 // UTILS -----------------------------------------------------------------------
 
 fn snapshot(el: Element(msg), title: String) -> Nil {


### PR DESCRIPTION
Adds two new default value attributes for the defaultChecked and defaultSelected dom interface properties. Included two birdie snapshots to test the html writing machinery.

Admittedly this PR is pretty much rote copying the way default_value was implemented. 

Fixes #353 

I added the `* text=auto` to .gitattributes so that line endings are normalized. 

Very new to gleam so I'm not sure if you want all those birdie snapshot version bumps included; I can fix that if necessary :) 

