### PR TITLE
Advanced elements should not have the HTML tag voidness checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ request to fix it.
 - [lustre/event] Correctly document the unit used for `debounce` and `throttle`.
 - [lustre/runtime] Fix a bug where holding a `WeakRef` to a context subscription function would cause it to GC unpredictably.
 - [lustre/server_component] Fixed a bug where listening to attribute changes would crash the JavaScript server component runtime.
+- [lustre/element] Change `element.advanced` to not override the voidness of the element based on a builtin list of HTML elements. This functionality is maintained for `element.element` and `element.namespaced`.
 
 ## [v5.3.4] - 2025-08-23
 

--- a/birdie_snapshots/[html]_advanced_elements_should_be_able_to_be_void_and_non_void.accepted
+++ b/birdie_snapshots/[html]_advanced_elements_should_be_able_to_be_void_and_non_void.accepted
@@ -1,0 +1,10 @@
+---
+version: 1.4.0
+title: [html] Advanced elements should be able to be void and non-void
+---
+<div>
+  <link>
+    Wibble
+  </link>
+  <link>
+</div>

--- a/birdie_snapshots/[html]_keyed_advanced_elements_should_be_able_to_be_void_and_non_void.accepted
+++ b/birdie_snapshots/[html]_keyed_advanced_elements_should_be_able_to_be_void_and_non_void.accepted
@@ -1,0 +1,10 @@
+---
+version: 1.4.0
+title: [html] Keyed advanced elements should be able to be void and non-void
+---
+<div>
+  <link data-lustre-key="non-void">
+    Wibble
+  </link>
+  <link data-lustre-key="void">
+</div>

--- a/birdie_snapshots/[html]_semi_advanced_keyed_tag_functions_should_still_have_the_html_void_checking.accepted
+++ b/birdie_snapshots/[html]_semi_advanced_keyed_tag_functions_should_still_have_the_html_void_checking.accepted
@@ -1,0 +1,9 @@
+---
+version: 1.4.0
+title: [html] Semi-advanced keyed tag functions should still have the HTML void checking
+---
+<div>
+  <link data-lustre-key="wee">
+  <link data-lustre-key="oo">
+  <link xmlns="rapture" data-lustre-key="goes the ambulance"></link>
+</div>

--- a/birdie_snapshots/[html]_semi_advanced_tag_functions_should_still_have_the_html_void_checking.accepted
+++ b/birdie_snapshots/[html]_semi_advanced_tag_functions_should_still_have_the_html_void_checking.accepted
@@ -1,0 +1,9 @@
+---
+version: 1.4.0
+title: [html] Semi-advanced tag functions should still have the HTML void checking
+---
+<div>
+  <link>
+  <link>
+  <link xmlns="bitter-end"></link>
+</div>

--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -111,7 +111,7 @@ pub fn element(
     children: children,
     keyed_children: mutable_map.new(),
     self_closing: False,
-    void: False,
+    void: vnode.is_void_html_element(tag, ""),
   )
 }
 
@@ -133,7 +133,7 @@ pub fn namespaced(
     children:,
     keyed_children: mutable_map.new(),
     self_closing: False,
-    void: False,
+    void: vnode.is_void_html_element(tag, namespace),
   )
 }
 

--- a/src/lustre/element/keyed.gleam
+++ b/src/lustre/element/keyed.gleam
@@ -87,7 +87,7 @@ pub fn element(
     children:,
     keyed_children:,
     self_closing: False,
-    void: False,
+    void: vnode.is_void_html_element(tag, ""),
   )
 }
 
@@ -117,7 +117,7 @@ pub fn namespaced(
     children:,
     keyed_children:,
     self_closing: False,
-    void: False,
+    void: vnode.is_void_html_element(tag, namespace),
   )
 }
 

--- a/src/lustre/vdom/vnode.gleam
+++ b/src/lustre/vdom/vnode.gleam
@@ -99,11 +99,11 @@ pub fn element(
     children:,
     keyed_children:,
     self_closing:,
-    void: void || is_void_element(tag, namespace),
+    void:,
   )
 }
 
-fn is_void_element(tag: String, namespace: String) -> Bool {
+pub fn is_void_html_element(tag: String, namespace: String) -> Bool {
   case namespace {
     "" ->
       case tag {

--- a/test/snapshot/html_test.gleam
+++ b/test/snapshot/html_test.gleam
@@ -48,6 +48,34 @@ pub fn void_elements_test() {
   input |> snapshot("Void elements should render as such")
 }
 
+pub fn element_namespaced_void_test() {
+  use <- lustre_test.test_filter("element_namespaced_void_test")
+
+  let input =
+    html.div([], [
+      element.element("link", [], []),
+      element.namespaced("", "link", [], []),
+      element.namespaced("bitter-end", "link", [], []),
+    ])
+
+  input
+  |> snapshot(
+    "Semi-advanced tag functions should still have the HTML void checking",
+  )
+}
+
+pub fn void_advanced_elements_test() {
+  use <- lustre_test.test_filter("void_advanced_elements_test")
+
+  let input =
+    html.div([], [
+      element.advanced("", "link", [], [element.text("Wibble")], False, False),
+      element.advanced("", "link", [], [], False, True),
+    ])
+
+  input |> snapshot("Advanced elements should be able to be void and non-void")
+}
+
 pub fn keyed_void_elements_test() {
   use <- lustre_test.test_filter("keyed_void_elements_test")
 
@@ -69,6 +97,38 @@ pub fn keyed_void_elements_test() {
     ])
 
   input |> snapshot("Keyed void elements should render as such")
+}
+
+pub fn keyed_element_namespaced_void_test() {
+  use <- lustre_test.test_filter("keyed_element_namespaced_void_test")
+
+  let input =
+    keyed.div([], [
+      #("wee", element.element("link", [], [])),
+      #("oo", element.namespaced("", "link", [], [])),
+      #("goes the ambulance", element.namespaced("rapture", "link", [], [])),
+    ])
+
+  input
+  |> snapshot(
+    "Semi-advanced keyed tag functions should still have the HTML void checking",
+  )
+}
+
+pub fn keyed_void_advanced_elements_test() {
+  use <- lustre_test.test_filter("keyed_void_advanced_elements_test")
+
+  let input =
+    keyed.div([], [
+      #(
+        "non-void",
+        element.advanced("", "link", [], [element.text("Wibble")], False, False),
+      ),
+      #("void", element.advanced("", "link", [], [], False, True)),
+    ])
+
+  input
+  |> snapshot("Keyed advanced elements should be able to be void and non-void")
 }
 
 // FRAGMENT TESTS --------------------------------------------------------------


### PR DESCRIPTION
When I render an advanced element with `element.advanced("", "link", [], [contents], False, False)`, silly as it may seem, it should not be void. It should instead be `<link>contents</link>`.

The checking is maintained for `element.element` and `element.namespaced`. The same changes are done for the keyed functions.