### PR TITLE
Always clean up server component process in examples

### DIFF
--- a/examples/06-server-components/01-basic-setup/src/app.gleam
+++ b/examples/06-server-components/01-basic-setup/src/app.gleam
@@ -210,4 +210,7 @@ fn loop_counter_socket(
 fn close_counter_socket(state: CounterSocket) -> Nil {
   server_component.deregister_subject(state.self)
   |> lustre.send(to: state.component)
+
+  lustre.shutdown()
+  |> lustre.send(to: state.component)
 }

--- a/examples/06-server-components/02-attributes-and-events/src/app.gleam
+++ b/examples/06-server-components/02-attributes-and-events/src/app.gleam
@@ -189,4 +189,7 @@ fn loop_counter_socket(
 fn close_counter_socket(state: CounterSocket) -> Nil {
   server_component.deregister_subject(state.self)
   |> lustre.send(to: state.component)
+
+  lustre.shutdown()
+  |> lustre.send(to: state.component)
 }

--- a/examples/06-server-components/03-event-include/src/app.gleam
+++ b/examples/06-server-components/03-event-include/src/app.gleam
@@ -158,4 +158,7 @@ fn loop_chat_socket(
 fn close_chat_socket(state: ChatSocket) -> Nil {
   server_component.deregister_subject(state.self)
   |> lustre.send(to: state.component)
+
+  lustre.shutdown()
+  |> lustre.send(to: state.component)
 }

--- a/examples/06-server-components/04-multiple-clients/src/app.gleam
+++ b/examples/06-server-components/04-multiple-clients/src/app.gleam
@@ -163,4 +163,7 @@ fn loop_whiteboard_socket(
 fn close_whiteboard_socket(state: WhiteboardSocket) -> Nil {
   server_component.deregister_subject(state.self)
   |> lustre.send(to: state.component)
+
+  lustre.shutdown()
+  |> lustre.send(to: state.component)
 }


### PR DESCRIPTION
Came across this:

https://github.com/JonasGruenwald/spectator/pull/14#issuecomment-3413180489

And thought it might be helpful if the server components examples all showed proper cleanup of the server component processes, so that folks working off the examples don't create memory leaks in their apps accidentally