### PR TITLE
Delay synchronous renders using a microtask

### DIFF
--- a/src/lustre/runtime/client/component.ffi.mjs
+++ b/src/lustre/runtime/client/component.ffi.mjs
@@ -226,7 +226,7 @@ export const make_component = ({ init, update, view, config }, name) => {
         const decoded = decode(value, decoder);
 
         if (decoded.isOk()) {
-        this.dispatch(decoded[0], true);
+          this.dispatch(decoded[0], true);
         }
       },
     });


### PR DESCRIPTION
The first render stays synchronous to make sure the DOM is setup properly for context events. We don't have to cancelAnimationFrame anymore since when we have a timer set already but we want to render synchronously, it will definitely always will render in the current frame.