### PR TITLE
📝 Fix anchors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@
 - [Where next](#where-next)
 - [Support](#support)
 
-## Features {#features}
+<a name="features"></a>
+## Features
 
 - A **declarative**, functional API for constructing HTML. No templates, no macros,
   just Gleam.
@@ -77,7 +78,8 @@
 
 - **Server-side rendering** for static HTML templating.
 
-## Example {#example}
+<a name="example"></a>
+## Example
 
 Lustre comes with [over 20 examples](https://hexdocs.pm/lustre/reference/examples.html)!
 Here's what it looks like:
@@ -123,7 +125,8 @@ fn view(model) {
 }
 ```
 
-## Philosophy {#philosophy}
+<a name="philosophy"></a>
+## Philosophy
 
 Lustre is an _opinionated_ framework for building small-to-medium-sized Web
 applications. Modern frontend development is hard and complex. Some of that
@@ -146,7 +149,8 @@ an existing Lustre application, export them as a standalone Web Component, or ru
 them on the server with a minimal runtime for patching the DOM. Lustre calls these
 **universal components** and they're written with Gleam's multiple targets in mind.
 
-## Installation {#installation}
+<a name="installation"></a>
+## Installation
 
 Lustre is published on [Hex](https://hex.pm/packages/lustre)! You can add it to
 your Gleam projects from the command line:
@@ -166,7 +170,8 @@ like to install:
 gleam add --dev lustre_dev_tools
 ```
 
-## Where next {#where-next}
+<a name="where-next"></a>
+## Where next
 
 To get up to speed with Lustre, check out the [quickstart guide](https://hexdocs.pm/lustre/guide/01-quickstart.html).
 If you prefer to see some code, the [examples](https://github.com/lustre-labs/lustre/tree/main/examples)
@@ -176,7 +181,8 @@ aspects of the framework.
 You can also read through the documentation and API reference on
 [HexDocs](https://hexdocs.pm/lustre).
 
-## Support {#support}
+<a name="support"></a>
+## Support
 
 Lustre is mostly built by just me, [Hayleigh](https://github.com/hayleigh-dot-dev),
 around two jobs. If you'd like to support my work, you can [sponsor me on GitHub](https://github.com/sponsors/hayleigh-dot-dev).


### PR DESCRIPTION
Github markdown doesn't seem to support the extended syntax to manually set the heading id.
I've replaced them with manual anchors so you can still change the headers without touching the table of contents.