### PR TITLE
update examples/03-effects/04-local-storage to formal@3 api

### DIFF
--- a/examples/03-effects/04-local-storage/gleam.toml
+++ b/examples/03-effects/04-local-storage/gleam.toml
@@ -6,4 +6,4 @@ dev-dependencies = { lustre_dev_tools = ">= 2.0.0 and < 3.0.0" }
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 lustre = { path = "../../../" }
 gleam_json = ">= 2.3.0 and < 4.0.0"
-formal = ">= 2.2.0 and < 3.0.0"
+formal = ">= 3.0.0 and < 4.0.0"

--- a/examples/03-effects/04-local-storage/src/app.gleam
+++ b/examples/03-effects/04-local-storage/src/app.gleam
@@ -3,7 +3,6 @@
 import formal/form
 import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode.{type Decoder}
-import gleam/function
 import gleam/int
 import gleam/json.{type Json}
 import gleam/list
@@ -188,14 +187,18 @@ fn view_input(
 ) -> Element(msg) {
   let on_submit =
     event.on_submit(fn(fields) {
-      form.decoding(into: function.identity)
-      |> form.with_values(fields)
-      |> form.field("title", form.string |> form.and(form.must_not_be_empty))
-      |> form.finish
+      form.new({
+        use title <- form.field("title", {
+          form.parse_string
+          |> form.check_not_empty
+        })
+        form.success(title)
+      })
+      |> form.set_values(fields)
+      |> form.run
       |> result.replace_error(Nil)
       |> handle_submit
     })
-
   html.form([attribute.id("new-todo"), on_submit], [
     html.label([attribute.for("title"), attribute.class("block text-sm mb-2")], [
       html.text("What do you need to do?"),


### PR DESCRIPTION
Current examples/03-effects/04-local-storage project is still on formal@2, which is troublesome for new learners who probably just look at the gleam.toml (as I did), see formal and do a `gleam add formal` which will bring down @3 and the example breaks.  I've updated the example to the current formal@3 api
