### PR TITLE
Add apis for naming and supervising server components.

### DIFF
--- a/src/lustre/server_component.gleam
+++ b/src/lustre/server_component.gleam
@@ -243,8 +243,6 @@ pub fn subject(runtime: Runtime(msg)) -> Subject(RuntimeMessage(msg)) {
 /// > **Note**: this function is not available on the JavaScript target.
 ///
 pub fn pid(runtime: Runtime(msg)) -> Pid {
-  // This is ok to assert *for now* because Lustre does not support named processes
-  // for server components.
   let assert Ok(pid) = process.subject_owner(subject(runtime))
 
   pid


### PR DESCRIPTION
Adds three new functions:

- `lustre.named` to attach a `Name` to an `App` before it is started.
- `lustre.supervised` to create a child specification suitable for static supervision from an `App`.
- `lustre.factory` to create a factory supervisor capable of starting multiple instances of an `App` dynamically.