### PR TITLE
:bug: fix a small scheduler bug 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ request to fix it.
 ### Changed
 
 - [lustre/event] Fixed a bug where moving keyed elements would sometimes remove their event listeners.
+- [lustre/runtime] Fixed a bug where an extra frame would be scheduled after `before_paint` and `after_paint` effects.
 
 ## [v5.6.0] - 2026-02-16
 


### PR DESCRIPTION
where an extra new frame would be scheduled after `before_paint` and `after_paint` effects even if no changes happened.

I noticed this while making the talk and logging where `view` was called.

Previously, we just used `tick` to process these effects - but tick always scheduled a frame afterwards since it was supposed to be called after a message dispatched. For async effects, there is no message that gets dispatched first, so needing to re-render is not guaranteed - a before/after effect that just causes some side-effect cannot influence the `view`.

This change makes that clear by calling `scheduleRender` and `handleEffects` inside `dispatch`, and only calling `scheduleRender` when processing async effects when an additional message was queued and sent to `update`.