### PR TITLE
:bug: Fix to_document_string producing malformed HTML for mapped elements

### DIFF
--- a/src/lustre/element.gleam
+++ b/src/lustre/element.gleam
@@ -13,7 +13,7 @@ import gleam/string_tree.{type StringTree}
 import lustre/attribute.{type Attribute}
 import lustre/internals/mutable_map
 import lustre/internals/ref
-import lustre/vdom/vnode.{Element}
+import lustre/vdom/vnode.{Element, Map}
 
 // TYPES -----------------------------------------------------------------------
 
@@ -285,6 +285,18 @@ pub fn to_string(element: Element(msg)) -> String {
   vnode.to_string(element)
 }
 
+/// Unwrap any `Map` vnodes to peek at the underlying element. This is used by
+/// `to_document_string` and `to_document_string_tree` to correctly detect
+/// `<html>`, `<head>`, and `<body>` elements even when they have been wrapped
+/// by `element.map`.
+///
+fn unwrap_map(el: Element(msg)) -> Element(msg) {
+  case el {
+    Map(child: child, ..) -> unwrap_map(child)
+    _ -> el
+  }
+}
+
 /// Converts an element to a string like [`to_string`](#to_string), but prepends
 /// a `<!doctype html>` declaration to the string. This is useful for rendering
 /// complete HTML documents.
@@ -293,7 +305,7 @@ pub fn to_string(element: Element(msg)) -> String {
 /// a `html` and `body` element.
 ///
 pub fn to_document_string(el: Element(msg)) -> String {
-  vnode.to_string(case el {
+  vnode.to_string(case unwrap_map(el) {
     Element(tag: "html", ..) -> el
     Element(tag: "head", ..) | Element(tag: "body", ..) ->
       element("html", [], [el])
@@ -321,7 +333,7 @@ pub fn to_string_tree(element: Element(msg)) -> StringTree {
 ///
 pub fn to_document_string_tree(el: Element(msg)) -> StringTree {
   vnode.to_string_tree(
-    case el {
+    case unwrap_map(el) {
       Element(tag: "html", ..) -> el
       Element(tag: "head", ..) | Element(tag: "body", ..) ->
         element("html", [], [el])

--- a/test/unit/to_document_string_test.gleam
+++ b/test/unit/to_document_string_test.gleam
@@ -1,0 +1,173 @@
+// IMPORTS ---------------------------------------------------------------------
+
+import gleam/string
+import gleam/string_tree
+import lustre/attribute
+import lustre/element
+import lustre/element/html
+import lustre_test
+
+// TO_DOCUMENT_STRING TESTS ----------------------------------------------------
+
+pub fn to_document_string_html_element_test() {
+  use <- lustre_test.test_filter("to_document_string_html_element_test")
+
+  let page =
+    html.html([], [
+      html.head([], []),
+      html.body([], [html.h1([], [html.text("Hello")])]),
+    ])
+
+  let result = element.to_document_string(page)
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert string.contains(result, "<html>")
+  assert !double_html_body(result)
+}
+
+pub fn to_document_string_head_element_test() {
+  use <- lustre_test.test_filter("to_document_string_head_element_test")
+
+  let el = html.head([], [html.title([], "Test")])
+  let result = element.to_document_string(el)
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert string.contains(result, "<html>")
+  assert string.contains(result, "<head>")
+}
+
+pub fn to_document_string_body_element_test() {
+  use <- lustre_test.test_filter("to_document_string_body_element_test")
+
+  let el = html.body([], [html.p([], [html.text("Hi")])])
+  let result = element.to_document_string(el)
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert string.contains(result, "<html>")
+  assert string.contains(result, "<body>")
+}
+
+pub fn to_document_string_other_element_test() {
+  use <- lustre_test.test_filter("to_document_string_other_element_test")
+
+  let el = html.div([], [html.text("Hello")])
+  let result = element.to_document_string(el)
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert string.contains(result, "<html><body>")
+  assert string.contains(result, "<div>Hello</div>")
+}
+
+pub fn to_document_string_mapped_html_element_test() {
+  use <- lustre_test.test_filter("to_document_string_mapped_html_element_test")
+
+  let page =
+    html.html([], [
+      html.head([], [
+        html.meta([attribute.attribute("charset", "utf-8")]),
+        html.link([
+          attribute.attribute("rel", "icon"),
+          attribute.attribute("href", "/favicon.ico"),
+        ]),
+        html.title([], "Test Page"),
+      ]),
+      html.body([], [html.h1([], [html.text("Hello")])]),
+    ])
+
+  let mapped = element.map(page, fn(_) { Nil })
+  let result = element.to_document_string(mapped)
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert string.contains(result, "<head>")
+  assert string.contains(result, "<title>Test Page</title>")
+  assert !double_html_body(result)
+}
+
+pub fn to_document_string_double_mapped_html_element_test() {
+  use <- lustre_test.test_filter(
+    "to_document_string_double_mapped_html_element_test",
+  )
+
+  let page =
+    html.html([], [
+      html.head([], []),
+      html.body([], [html.text("Hi")]),
+    ])
+
+  let double_mapped =
+    page
+    |> element.map(fn(_) { Nil })
+    |> element.map(fn(_) { Nil })
+
+  let result = element.to_document_string(double_mapped)
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert !double_html_body(result)
+}
+
+pub fn to_document_string_mapped_head_element_test() {
+  use <- lustre_test.test_filter("to_document_string_mapped_head_element_test")
+
+  let el = html.head([], [html.title([], "Test")])
+  let mapped = element.map(el, fn(_) { Nil })
+  let result = element.to_document_string(mapped)
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert string.contains(result, "<html>")
+  assert string.contains(result, "<head>")
+  assert !string.contains(result, "<body>")
+}
+
+pub fn to_document_string_mapped_body_element_test() {
+  use <- lustre_test.test_filter("to_document_string_mapped_body_element_test")
+
+  let el = html.body([], [html.p([], [html.text("Hi")])])
+  let mapped = element.map(el, fn(_) { Nil })
+  let result = element.to_document_string(mapped)
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert string.contains(result, "<html>")
+  assert string.contains(result, "<body>")
+}
+
+pub fn to_document_string_mapped_other_element_test() {
+  use <- lustre_test.test_filter("to_document_string_mapped_other_element_test")
+
+  let el = html.div([], [html.text("Hello")])
+  let mapped = element.map(el, fn(_) { Nil })
+  let result = element.to_document_string(mapped)
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert string.contains(result, "<html><body>")
+}
+
+// TO_DOCUMENT_STRING_TREE TESTS -----------------------------------------------
+
+pub fn to_document_string_tree_mapped_html_element_test() {
+  use <- lustre_test.test_filter(
+    "to_document_string_tree_mapped_html_element_test",
+  )
+
+  let page =
+    html.html([], [
+      html.head([], [html.title([], "Test")]),
+      html.body([], [html.text("Hi")]),
+    ])
+
+  let mapped = element.map(page, fn(_) { Nil })
+  let result =
+    element.to_document_string_tree(mapped)
+    |> string_tree.to_string
+
+  assert string.starts_with(result, "<!doctype html>\n")
+  assert !double_html_body(result)
+}
+
+// UTILS -----------------------------------------------------------------------
+
+/// Check if the output contains the telltale sign of the double-wrapping bug:
+/// `<html><body>` appearing before the actual document content.
+///
+fn double_html_body(html: String) -> Bool {
+  string.contains(html, "<html><body><!-- lustre:map -->")
+}


### PR DESCRIPTION
## Summary

- `to_document_string` and `to_document_string_tree` fail to detect `<html>`, `<head>`, and `<body>` elements when they've been passed through `element.map`, because the outermost vnode is `Map` instead of `Element`
- This causes the catch-all branch to wrap everything in an extra `<html><body>`, producing malformed HTML where all `<head>` content is ignored by browsers
- Adds an `unwrap_map` helper that peeks through `Map` vnodes before pattern matching, while preserving the original element (with mapper intact) in the output

Closes #447