### PR TITLE
🔧 bump mist dependency in server examples

### DIFF
--- a/examples/01-basics/01-hello-world/README.md
+++ b/examples/01-basics/01-hello-world/README.md
@@ -29,9 +29,9 @@ about pure functions by reading [the hint](https://github.com/lustre-labs/lustre
 
 ## Running the Example
 
-This example and all the others in this repository use Lustre's
-[dev tools](https://hex.pm/packages/lustre_dev_tools) package to build and run
-the app. Just run:
+This example and all the others in this repository (except the server examples)
+use Lustre's [dev tools](https://hex.pm/packages/lustre_dev_tools) package to
+build and run the app. Just run:
 
 ```bash
 gleam run -m lustre/dev start

--- a/examples/06-server-components/01-basic-setup/gleam.toml
+++ b/examples/06-server-components/01-basic-setup/gleam.toml
@@ -8,4 +8,4 @@ gleam_json = ">= 2.3.0 and < 4.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.60.0 and < 2.0.0"
 lustre = { path = "../../../" }
-mist = ">= 5.0.0 and < 6.0.0"
+mist = ">= 6.0.2 and < 7.0.0"

--- a/examples/06-server-components/02-attributes-and-events/gleam.toml
+++ b/examples/06-server-components/02-attributes-and-events/gleam.toml
@@ -8,4 +8,4 @@ gleam_json = ">= 2.3.0 and < 4.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.60.0 and < 2.0.0"
 lustre = { path = "../../../" }
-mist = ">= 5.0.0 and < 6.0.0"
+mist = ">= 6.0.2 and < 7.0.0"

--- a/examples/06-server-components/03-event-include/gleam.toml
+++ b/examples/06-server-components/03-event-include/gleam.toml
@@ -8,4 +8,4 @@ gleam_json = ">= 2.3.0 and < 4.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 lustre = { path = "../../../" }
-mist = ">= 5.0.0 and < 6.0.0"
+mist = ">= 6.0.2 and < 7.0.0"

--- a/examples/06-server-components/04-multiple-clients/gleam.toml
+++ b/examples/06-server-components/04-multiple-clients/gleam.toml
@@ -8,4 +8,4 @@ gleam_json = ">= 2.3.0 and < 4.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.60.0 and < 2.0.0"
 lustre = { path = "../../../" }
-mist = ">= 5.0.0 and < 6.0.0"
+mist = ">= 6.0.2 and < 7.0.0"

--- a/examples/06-server-components/05-publish-subscribe/gleam.toml
+++ b/examples/06-server-components/05-publish-subscribe/gleam.toml
@@ -8,5 +8,5 @@ gleam_json = ">= 2.3.0 and < 4.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.60.0 and < 2.0.0"
 lustre = { path = "../../../" }
-mist = ">= 5.0.0 and < 6.0.0"
+mist = ">= 6.0.2 and < 7.0.0"
 group_registry = ">= 1.0.0 and < 2.0.0"

--- a/examples/06-server-components/06-csrf-protection/gleam.toml
+++ b/examples/06-server-components/06-csrf-protection/gleam.toml
@@ -8,5 +8,5 @@ gleam_json = ">= 2.3.0 and < 4.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.60.0 and < 2.0.0"
 lustre = { path = "../../../" }
-mist = ">= 5.0.0 and < 6.0.0"
+mist = ">= 6.0.2 and < 7.0.0"
 youid = ">= 1.5.1 and < 2.0.0"


### PR DESCRIPTION
Went through all the examples (thanks for these!) and found that these server-side ones need the `mist` dependency bumped -- much like https://github.com/lustre-labs/dev-tools/pull/160.

Also updated a note about running the examples.