### PR TITLE
🐛 fix configure_server_component import

### DIFF
--- a/src/lustre/runtime/server/runtime.ffi.mjs
+++ b/src/lustre/runtime/server/runtime.ffi.mjs
@@ -25,7 +25,7 @@ import {
   //
   Message$isSystemRequestedShutdown,
 } from "./runtime.mjs";
-import * as Component from "../../component.mjs";
+import * as App from "../app.mjs";
 import * as Effect from "../../effect.mjs";
 import * as Transport from "../transport.mjs";
 import {
@@ -253,7 +253,7 @@ export class Runtime {
 }
 
 export const start = (app, start_arguments) => {
-  const config = Component.to_server_component_config(app.config);
+  const config = App.configure_server_component(app.config);
 
   return Result$Ok(
     new Runtime(app.init, app.update, app.view, config, start_arguments),


### PR DESCRIPTION
Building a lustre-based application with vite yields the following warning:

```
[IMPORT_IS_UNDEFINED] Warning: Import `to_server_component_config` will always be undefined because there is no matching export in 'build/dev/javascript/lustre/lustre/component.mjs'
     ╭─[ build/dev/javascript/lustre/lustre/runtime/server/runtime.ffi.mjs:256:18 ]
     │
 256 │   const config = Component.to_server_component_config(app.config);
```

This PR fixes the outdated import to point to the new function. Build runs without a warning now.