### PR TITLE
add closedby, command, and commandfor attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ request to fix it.
 
 ### Added
 
+- [lustre/attribute] Added `closedby`, `command`, and `commandfor` attributes.
 - [lustre/component] Component's can be notified of form disabled events using the `on_form_disabled` configuration option.
 - [lustre/server_component] The server component client runtime will now detect and include any CSRF token embedded in the page as a query parameter in the initial WebSocket connection URL.
 

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -200,6 +200,15 @@ pub fn command(value: String) -> Attribute(message) {
   attribute("command", value)
 }
 
+/// References the ID of the element that receives the command specified by
+/// the `command` attribute.
+///
+/// The attribute is supported by the `<button>` element.
+/// 
+pub fn commandfor(value: String) -> Attribute(message) {
+  attribute("commandfor", value)
+}
+
 /// Indicates whether the element's content is editable by the user, allowing them
 /// to modify the HTML content directly. The following values are accepted:
 ///

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -170,6 +170,18 @@ fn do_classes(names: List(#(String, Bool)), class: String) -> String {
   }
 }
 
+/// Specifies the user actions that can close a `<dialog>` element.
+///
+/// | Value          | Description                                                                                       |
+/// |----------------|---------------------------------------------------------------------------------------------------|
+/// | "any"          | The dialog can be closed with any method.                                                         |
+/// | "closerequest" | The dialog can be closed with a platform-specific user action or a developer-specified mechanism. |
+/// | "none"         | The dialog can be closed with a developer-specified mechanism.                                    |
+///
+pub fn closedby(value: String) -> Attribute(message) {
+  attribute("closedby", value)
+}
+
 /// Indicates whether the element's content is editable by the user, allowing them
 /// to modify the HTML content directly. The following values are accepted:
 ///

--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -182,6 +182,24 @@ pub fn closedby(value: String) -> Attribute(message) {
   attribute("closedby", value)
 }
 
+/// Specifies the action to be performed on the dialog or popover referenced by
+/// the `commandfor` attribute.
+///
+/// The attribute is supported by the `<button>` element.
+///
+/// | Value            | Description                                                    |
+/// |------------------|----------------------------------------------------------------|
+/// | "show-modal"     | Opens a `<dialog>` as a modal.                                 |
+/// | "close"          | Closes a `<dialog>`.                                           |
+/// | "request-close"  | Triggers a `cancel` event on a `<dialog>`.                     |
+/// | "show-popover"   | Shows a popover.                                               |
+/// | "hide-popover"   | Hides a popover.                                               |
+/// | "toggle-popover" | Toggles the visibility of a popover.                           |
+///
+pub fn command(value: String) -> Attribute(message) {
+  attribute("command", value)
+}
+
 /// Indicates whether the element's content is editable by the user, allowing them
 /// to modify the HTML content directly. The following values are accepted:
 ///


### PR DESCRIPTION
Adds the `command` and `commandfor` attributes of the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) that can be used to control dialogs and popovers, as well as the `closedby` attribute that can be used on dialog elements.