### PR TITLE
fix(server-runtime): use this.#config instead of bare config in send()

### DIFF
--- a/src/lustre/runtime/server/runtime.ffi.mjs
+++ b/src/lustre/runtime/server/runtime.ffi.mjs
@@ -91,15 +91,15 @@ export class Runtime {
         ),
       );
 
-      if (Option.Option$isSome(config.on_connect)) {
-        this.#dispatch(Option.Option$Some$0(config.on_connect));
+      if (Option.Option$isSome(this.#config.on_connect)) {
+        this.#dispatch(Option.Option$Some$0(this.#config.on_connect));
       }
     } else if (Message$isClientDeregisteredCallback(message)) {
       const { callback } = message;
       this.#callbacks.delete(callback);
 
-      if (Option.Option$isSome(config.on_disconnect)) {
-        this.#dispatch(Option.Option$Some$0(config.on_disconnect));
+      if (Option.Option$isSome(this.#config.on_disconnect)) {
+        this.#dispatch(Option.Option$Some$0(this.#config.on_disconnect));
       }
     } else if (Message$isEffectDispatchedMessage(message)) {
       const { message } = message;


### PR DESCRIPTION
## Bug

In `runtime.ffi.mjs`, the `send()` method references `config` (the constructor parameter name) instead of `this.#config` when checking `on_connect` and `on_disconnect` callbacks. This causes a `ReferenceError` at runtime when the server transport tries to dispatch lifecycle hooks.

## Fix

Changed `config.on_connect` → `this.#config.on_connect` and `config.on_disconnect` → `this.#config.on_disconnect` on the two affected lines.

Closes #463