### PR TITLE
fix(server): use this.#config in send() instead of bare config

### DIFF
--- a/src/lustre/runtime/server/runtime.ffi.mjs
+++ b/src/lustre/runtime/server/runtime.ffi.mjs
@@ -91,15 +91,15 @@ export class Runtime {
         ),
       );
 
-      if (Option.Option$isSome(config.on_connect)) {
-        this.#dispatch(Option.Option$Some$0(config.on_connect));
+      if (Option.Option$isSome(this.#config.on_connect)) {
+        this.#dispatch(Option.Option$Some$0(this.#config.on_connect));
       }
     } else if (Message$isClientDeregisteredCallback(message)) {
       const { callback } = message;
       this.#callbacks.delete(callback);
 
-      if (Option.Option$isSome(config.on_disconnect)) {
-        this.#dispatch(Option.Option$Some$0(config.on_disconnect));
+      if (Option.Option$isSome(this.#config.on_disconnect)) {
+        this.#dispatch(Option.Option$Some$0(this.#config.on_disconnect));
       }
     } else if (Message$isEffectDispatchedMessage(message)) {
       const { message } = message;


### PR DESCRIPTION
Fixes #465

The `send()` method in the server runtime references the bare `config` constructor parameter when checking `on_connect` and `on_disconnect` callbacks. This causes a ReferenceError at runtime because `config` is not in scope inside the method body.

Replace with `this.#config` to match how the rest of the class accesses the stored configuration.