### PR TITLE
docs(guide): update outdated rendering lists hint

### DIFF
--- a/pages/guide/01-quickstart.md
+++ b/pages/guide/01-quickstart.md
@@ -425,10 +425,10 @@ fn view(model: Model) -> Element(Message) {
 }
 ```
 
-Depending on your network speed, you might notice that when you add a new cat
-the last cat image is duplicated for a moment before the new one appears. While
-we won't touch on it in this guide, you can learn more about why this happens and
-how to prevent it in the [rendering lists](https://github.com/lustre-labs/lustre/blob/main/pages/hints/rendering-lists.md)
+If you later build applications where list items can change position, such as
+when sorting or prepending items, you may encounter visual issues with images
+briefly appearing duplicated. You can learn more about why this happens and how
+to prevent it in the [rendering lists](https://github.com/lustre-labs/lustre/blob/main/pages/hints/rendering-lists.md)
 hint.
 
 ## What next

--- a/pages/hints/rendering-lists.md
+++ b/pages/hints/rendering-lists.md
@@ -14,9 +14,11 @@ function so Lustre can more accurately track which items in a list have changed.
 
 ## Seeing double
 
-One example of a visual issue can be seen in the [quickstart program](../guide/01-quickstart.md)
-where it is possible to briefly see a duplicated cat image before the new image has
-completely loaded. Let's walk through why this happens.
+One example of a visual issue can be seen with a variation of the [quickstart
+program](../guide/01-quickstart.md). If new cat images were added to the front
+of the list instead of being appended, it is possible to briefly see a duplicated
+cat image before the new image has completely loaded. Let's walk through why this
+happens.
 
 When you first click the increment button, the http side effect will eventually
 cause a cat image slug, let's call it `a`, to be added the model's `cat` list.


### PR DESCRIPTION
The quickstart's `update` function uses `list.append` to add cat images to the
end of the list, so the visual duplication described in the hint no longer
happens there. Updated the hint paragraph in `01-quickstart.md` to describe the
rendering-lists hint as general guidance for when list items change position,
and updated the "Seeing double" section in `rendering-lists.md` to frame the
prepend scenario as a hypothetical variation rather than the current quickstart
behavior.

Fixes #336