### PR TITLE
Always include `event.detail` in server component event payloads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ request to fix it.
 - [lustre/runtime] Fixed a bug where an extra frame would be scheduled after `before_paint` and `after_paint` effects.
 - [lustre/runtime] Fixed a bug where server-rendered HTML from sources other than Lustre would virtualise incorrectly.
 - [lustre/server_component] Reduce size of patches sent over the wire by compressing deeply nested patches.
-- [lustre/server_component] Server components can now always decode `event.detail` when present, even when it is not explicitly listed in `server_component.include`.
+- [lustre/server_component] Server components can now always decode `event.detail` from events emit but child Lustre apps, even when it is not explicitly listed in `server_component.include`.
 
 ## [v5.6.0] - 2026-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ request to fix it.
 - [lustre/runtime] Fixed a bug where an extra frame would be scheduled after `before_paint` and `after_paint` effects.
 - [lustre/runtime] Fixed a bug where server-rendered HTML from sources other than Lustre would virtualise incorrectly.
 - [lustre/server_component] Reduce size of patches sent over the wire by compressing deeply nested patches.
+- [lustre/server_component] Server components can now always decode `event.detail` when present, even when it is not explicitly listed in `server_component.include`.
 
 ## [v5.6.0] - 2026-02-16
 

--- a/src/lustre/runtime/client/runtime.ffi.mjs
+++ b/src/lustre/runtime/client/runtime.ffi.mjs
@@ -375,6 +375,10 @@ export class ContextRequestEvent extends Event {
 // we may be able to derive what fields to include by introspecting the decoders
 // itself and then this can go away.
 export class LustreEvent extends CustomEvent {
+  // We can't rely on `instanceof` checks because the server component client
+  // runtime is bundled on its own and thus will have its own copy of this class.
+  isLustreEvent = true;
+
   constructor(name, detail) {
     super(name, { detail, bubbles: true, composed: true });
   }

--- a/src/lustre/runtime/client/runtime.ffi.mjs
+++ b/src/lustre/runtime/client/runtime.ffi.mjs
@@ -123,13 +123,7 @@ export class Runtime {
   emit(event, data) {
     const target = this.root.host ?? this.root;
 
-    target.dispatchEvent(
-      new CustomEvent(event, {
-        detail: data,
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    target.dispatchEvent(new LustreEvent(event, data));
   }
 
   // Provide a context value for any child nodes that request it using the given
@@ -373,5 +367,15 @@ export class ContextRequestEvent extends Event {
     this.context = context;
     this.callback = callback;
     this.subscribe = subscribe;
+  }
+}
+
+// We subclass `CustomEvent` so we know when it's safe to automatically include
+// the `detail` field of an event in server component event handlers. In the future
+// we may be able to derive what fields to include by introspecting the decoders
+// itself and then this can go away.
+export class LustreEvent extends CustomEvent {
+  constructor(name, detail) {
+    super(name, { detail, bubbles: true, composed: true });
   }
 }

--- a/src/lustre/runtime/client/server_component.ffi.mjs
+++ b/src/lustre/runtime/client/server_component.ffi.mjs
@@ -412,7 +412,7 @@ export class ServerComponent extends HTMLElement {
 
     // For events emit but other Lustre components, we know it's always safe to
     // include the entire `detail` property as-is. 
-    if (event instanceof LustreEvent) {
+    if (event.isLustreEvent) {
       include.push("detail");
     }
 

--- a/src/lustre/runtime/client/server_component.ffi.mjs
+++ b/src/lustre/runtime/client/server_component.ffi.mjs
@@ -8,6 +8,7 @@ import { Reconciler } from "../../../../build/dev/javascript/lustre/lustre/vdom/
 import {
   adoptStylesheets,
   ContextRequestEvent,
+  LustreEvent,
 } from "../../../../build/dev/javascript/lustre/lustre/runtime/client/runtime.ffi.mjs";
 import {
   mount_kind,
@@ -265,7 +266,7 @@ export class ServerComponent extends HTMLElement {
       }
 
       case emit_kind: {
-        this.dispatchEvent(new CustomEvent(data.name, { detail: data.data }));
+        this.dispatchEvent(new LustreEvent(data.name, data.data));
 
         break;
       }
@@ -409,14 +410,11 @@ export class ServerComponent extends HTMLElement {
   #createServerEvent(event, include = []) {
     const data = {};
 
-    // When a `detail` property is present we always include it by default. In
-    // Lustre, the `detail` property is used to attach data to custom events so
-    // it's safe to assume that the user will want to decode it.
-    //
-    // Because this object is constructed by the runtime and not part of native
-    // events, it will be fully enumerable and thus we can just include the top-level
-    // property and be sure everything will serialise no problems.
-    include.push("detail");
+    // For events emit but other Lustre components, we know it's always safe to
+    // include the entire `detail` property as-is. 
+    if (event instanceof LustreEvent) {
+      include.push("detail");
+    }
 
     // It's overwhelmingly likely that if someone is listening for input or change
     // events that they're interested in the value of the input. Regardless of
@@ -439,6 +437,18 @@ export class ServerComponent extends HTMLElement {
       event.type === "keypress"
     ) {
       include.push("key");
+    }
+
+    // We have non-standard handling of the submit event in Lustre. We automatically
+    // extract the form fields into a special `formData` property on the event's
+    // `detail` field. This is because we need a way for normal Lustre apps to get
+    // at this data without needing to go through FFI to construct a `new FormData`
+    // themselves – this would be impossible for server components!
+    //
+    // If the user is handling a submit event they almost definitely want to know
+    // about the form's data, so we always include it.
+    if (event.type === "submit") {
+      include.push("detail.formData");
     }
 
     for (const property of include) {

--- a/src/lustre/runtime/client/server_component.ffi.mjs
+++ b/src/lustre/runtime/client/server_component.ffi.mjs
@@ -409,6 +409,15 @@ export class ServerComponent extends HTMLElement {
   #createServerEvent(event, include = []) {
     const data = {};
 
+    // When a `detail` property is present we always include it by default. In
+    // Lustre, the `detail` property is used to attach data to custom events so
+    // it's safe to assume that the user will want to decode it.
+    //
+    // Because this object is constructed by the runtime and not part of native
+    // events, it will be fully enumerable and thus we can just include the top-level
+    // property and be sure everything will serialise no problems.
+    include.push("detail");
+
     // It's overwhelmingly likely that if someone is listening for input or change
     // events that they're interested in the value of the input. Regardless of
     // whether they remember to include it in the event, we'll include it for them.
@@ -430,18 +439,6 @@ export class ServerComponent extends HTMLElement {
       event.type === "keypress"
     ) {
       include.push("key");
-    }
-
-    // We have non-standard handling of the submit event in Lustre. We automatically
-    // extract the form fields into a special `formData` property on the event's
-    // `detail` field. This is because we need a way for normal Lustre apps to get
-    // at this data without needing to go through FFI to construct a `new FormData`
-    // themselves – this would be impossible for server components!
-    //
-    // If the user is handling a submit event they almost definitely want to know
-    // about the form's data, so we always include it.
-    if (event.type === "submit") {
-      include.push("detail.formData");
     }
 
     for (const property of include) {


### PR DESCRIPTION
The `event.include` stuff is an unfortunate side-effect of the browser making sure event objects are not enumerable: users have to explicitly mark what properties they want to be included in the event payload for server components so they can decode them.

To smooth this over for most use cases, we always include things like `event.target.value` or `event.key` as the built-in event handlers decode those and because users handling these events will typically always want to get at these fields.

This PR now always includes `event.detail` in the server component event payload. Custom events emit by Lustre components (and in certain special cases, DOM events likes submit) have their custom data included in this property. Because this is a fairly obscure feature that isn't currently well-documented, folks would get tripped up trying to decode events from their client components.

It's safe to assume if an event has some custom `detail` that it's intended to be decoded, so automatically including it makes sense here.