### PR TITLE
Allow Lustre applications to subscribe to context changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ request to fix it.
 - [lustre/dev/simulate] Fixed a bug where simulated events on elements wrapped in `element.map` would not trigger.
 - [lustre/dev/query] Fixed a bug where the `text` query matcher did not match text exactly and instead matched if the element's text content contained the given text.
 - [lustre/dev/query] Fixed a bug where the `text` query would not treat `<br>` elements as newlines.
+- [lustre/component] The `on_context_change` option has been deprecated in favour of the explicit `effect.subscribe` and `effect.unsubscribe` effects.
 - [lustre/element] fixed a bug where `to_document_string` would sometimes mistakenly wrap a given `html` element again.
 - [lustre/event] Fixed a bug where moving keyed elements would sometimes remove their event listeners.
 - [lustre/runtime] Fixed a bug where an extra frame would be scheduled after `before_paint` and `after_paint` effects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ request to fix it.
 
 - [lustre/attribute] Added `closedby`, `command`, and `commandfor` attributes.
 - [lustre/component] Component's can be notified of form disabled events using the `on_form_disabled` configuration option.
+- [lustre/effect] Added the `subscribe` and `unsubscribe` effects so applications can now subscribe and unsubscribe to context changes from parent elements.
 - [lustre/server_component] The server component client runtime will now detect and include any CSRF token embedded in the page as a query parameter in the initial WebSocket connection URL.
 
 ### Changed

--- a/src/lustre/component.gleam
+++ b/src/lustre/component.gleam
@@ -152,6 +152,8 @@ pub fn on_property_change(
 /// Contexts can be any JavaScript object. For server components, contexts will
 /// be any _JSON-serialisable_ value.
 ///
+@deprecated("Static context subscriptions are deprecated in favour of the explicit
+`effect.subscribe` and `effect.unsubscribe` effects.")
 pub fn on_context_change(
   key: String,
   decoder: Decoder(message),

--- a/src/lustre/effect.gleam
+++ b/src/lustre/effect.gleam
@@ -63,6 +63,7 @@
 // IMPORTS ---------------------------------------------------------------------
 
 import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type Decoder}
 import gleam/json.{type Json}
 import gleam/list
 import lustre/internals/constants
@@ -107,6 +108,8 @@ type Actions(message) {
     select: fn(Selector(message)) -> Nil,
     root: fn() -> Dynamic,
     provide: fn(String, Json) -> Nil,
+    subscribe: fn(String, Decoder(message)) -> Nil,
+    unsubscribe: fn(String) -> Nil,
   )
 }
 
@@ -309,6 +312,10 @@ fn do_comap_actions(actions: Actions(b), f: fn(a) -> b) -> Actions(a) {
     select: fn(selector) { do_comap_select(actions, selector, f) },
     root: actions.root,
     provide: actions.provide,
+    subscribe: fn(name, decoder) {
+      actions.subscribe(name, decode.map(decoder, f))
+    },
+    unsubscribe: actions.unsubscribe,
   )
 }
 
@@ -342,14 +349,26 @@ fn do_comap_select(_, _, _) -> Nil {
 ///
 @internal
 pub fn perform(
-  effect: Effect(a),
-  dispatch: fn(a) -> Nil,
+  effect: Effect(message),
+  dispatch: fn(message) -> Nil,
   emit: fn(String, Json) -> Nil,
-  select: fn(Selector(a)) -> Nil,
+  select: fn(Selector(message)) -> Nil,
   root: fn() -> Dynamic,
   provide: fn(String, Json) -> Nil,
+  subscribe: fn(String, Decoder(message)) -> Nil,
+  unsubscribe: fn(String) -> Nil,
 ) -> Nil {
-  let actions = Actions(dispatch:, emit:, select:, root:, provide:)
+  let actions =
+    Actions(
+      dispatch:,
+      emit:,
+      select:,
+      root:,
+      provide:,
+      subscribe:,
+      unsubscribe:,
+    )
+
   use run <- list.each(effect.synchronous)
 
   run(actions)

--- a/src/lustre/effect.gleam
+++ b/src/lustre/effect.gleam
@@ -259,7 +259,7 @@ pub fn select(_sel) {
 /// 
 /// Once a value for the given key has been provided, children can [`subscribe`](#subscribe)
 /// to changes and receive updates any subsequent times `provide` is called with
-/// the same key. This facilities parent-child communication even in cases where
+/// the same key. This facilitates parent-child communication even in cases where
 /// the parent doesn't own the child element directly. 
 /// 
 /// **Note**: This is one half of the WCCG [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md)
@@ -276,11 +276,15 @@ pub fn provide(key: String, value: Json) -> Effect(message) {
 /// DOM. This effect will decode the context value from the first parent element
 /// that has _already provided_ a context for this key at least once. Once a
 /// subscription is set up, any changes to the context value will trigger additional
-/// messages to be dispatch with the new decoded value.
+/// messages to be dispatched with the new decoded value.
 /// 
 /// If no parent elements have provided a context for the given key at the time
 /// this effect is run, no subscription is set up even if a parent later provides
 /// a context for this key.
+/// 
+/// **Note**: Pay attention to timing and lifecycle differences between applications
+/// and components. Components that need to subscribe to a context should make sure
+/// this effect is called _after_ the component has [connected](./component.html#on_connect).
 /// 
 /// **Note**: This is one half of the WCCG [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md)
 /// and will work in tandem with not just Lustre components and applications, but
@@ -292,8 +296,8 @@ pub fn subscribe(key: String, decoder: Decoder(message)) -> Effect(message) {
   Effect(..empty, synchronous: constants.singleton_list(task))
 }
 
-/// Unsubscribe to a context [`subscription`](#subscribe) that was previously set
-/// up for this key.
+/// Unsubscribe from a context [`subscription`](#subscribe) that was previously
+/// set up for this key.
 /// 
 pub fn unsubscribe(key: String) -> Effect(message) {
   let task = fn(actions: Actions(message)) { actions.unsubscribe(key) }

--- a/src/lustre/effect.gleam
+++ b/src/lustre/effect.gleam
@@ -253,8 +253,50 @@ pub fn select(_sel) {
   empty
 }
 
+/// Provide a context value to child components in the DOM that this Lustre app
+/// didn't render. This occurs in components with that render one or more `<slot>`
+/// elements in their `view` function.
+/// 
+/// Once a value for the given key has been provided, children can [`subscribe`](#subscribe)
+/// to changes and receive updates any subsequent times `provide` is called with
+/// the same key. This facilities parent-child communication even in cases where
+/// the parent doesn't own the child element directly. 
+/// 
+/// **Note**: This is one half of the WCCG [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md)
+/// and will work in tandem with not just Lustre components but any third-party
+/// Web Component that implements the [`context-request` event](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md#the-context-request-event).
+/// 
 pub fn provide(key: String, value: Json) -> Effect(message) {
   let task = fn(actions: Actions(message)) { actions.provide(key, value) }
+
+  Effect(..empty, synchronous: constants.singleton_list(task))
+}
+
+/// Subscribe to changes for a context value provided by a parent element in the
+/// DOM. This effect will decode the context value from the first parent element
+/// that has _already provided_ a context for this key at least once. Once a
+/// subscription is set up, any changes to the context value will trigger additional
+/// messages to be dispatch with the new decoded value.
+/// 
+/// If no parent elements have provided a context for the given key at the time
+/// this effect is run, no subscription is set up even if a parent later provides
+/// a context for this key.
+/// 
+/// **Note**: This is one half of the WCCG [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md)
+/// and will work in tandem with not just Lustre components and applications, but
+/// any third-party Web Component that acts as a [context provider](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md#context-providers).
+/// 
+pub fn subscribe(key: String, decoder: Decoder(message)) -> Effect(message) {
+  let task = fn(actions: Actions(message)) { actions.subscribe(key, decoder) }
+
+  Effect(..empty, synchronous: constants.singleton_list(task))
+}
+
+/// Unsubscribe to a context [`subscription`](#subscribe) that was previously set
+/// up for this key.
+/// 
+pub fn unsubscribe(key: String) -> Effect(message) {
+  let task = fn(actions: Actions(message)) { actions.unsubscribe(key) }
 
   Effect(..empty, synchronous: constants.singleton_list(task))
 }

--- a/src/lustre/runtime/client/component.ffi.mjs
+++ b/src/lustre/runtime/client/component.ffi.mjs
@@ -11,7 +11,7 @@ import {
   Option$isSome,
   Option$Some$0,
 } from "../../../../gleam_stdlib/gleam/option.mjs";
-import * as Dict from "../../../../gleam_stdlib/gleam/dict.mjs";
+import { filter } from "../../../../gleam_stdlib/gleam/list.mjs";
 
 import {
   Error$BadComponentName,
@@ -217,7 +217,9 @@ export const make_component = ({ init, update, view, config }, name) => {
       // In future versions of Lustre the static `on_context_change` option will
       // go awawy in favour of the uniform `effect.subscribe` and then we won't
       // need this.
-      this.#initialContexts = Dict.delete(this.#initialContexts, key);
+      this.#initialContexts = filter(this.#initialContexts, (subscription) => {
+        return subscription[0] !== key;
+      });
     }
 
     // INTERNAL METHODS --------------------------------------------------------

--- a/src/lustre/runtime/client/component.ffi.mjs
+++ b/src/lustre/runtime/client/component.ffi.mjs
@@ -11,6 +11,7 @@ import {
   Option$isSome,
   Option$Some$0,
 } from "../../../../gleam_stdlib/gleam/option.mjs";
+import * as Dict from "../../../../gleam_stdlib/gleam/dict.mjs";
 
 import {
   Error$BadComponentName,
@@ -59,7 +60,7 @@ export const make_component = ({ init, update, view, config }, name) => {
 
     #runtime;
     #adoptedStyleNodes = [];
-    #contextSubscriptions = new Map();
+    #initialContexts = config.contexts;
 
     constructor() {
       super();
@@ -203,12 +204,28 @@ export const make_component = ({ init, update, view, config }, name) => {
       this.#runtime.provide(key, value);
     }
 
+    subscribe(key, decoder) {
+      this.#runtime.subscribe(key, decoder);
+    }
+
+    unsubscribe(key) {
+      this.#runtime.unsubscribe(key);
+      // Once a component is running and has a context subscription torn down, we
+      // don't want it to start back up again if the component is disconnected but
+      // later reconnected to the DOM.
+      //
+      // In future versions of Lustre the static `on_context_change` option will
+      // go awawy in favour of the uniform `effect.subscribe` and then we won't
+      // need this.
+      this.#initialContexts = Dict.delete(this.#initialContexts, key);
+    }
+
     // INTERNAL METHODS --------------------------------------------------------
 
     #requestContexts() {
       const requested = new Set();
 
-      iterate(config.contexts, ([key, decoder]) => {
+      iterate(this.#initialContexts, ([key, decoder]) => {
         // An empty key is not valid so we skip over any of those.
         if (!key) return;
 
@@ -217,39 +234,13 @@ export const make_component = ({ init, update, view, config }, name) => {
         // different decoder.
         if (requested.has(key)) return;
 
-        this.dispatchEvent(
-          new ContextRequestEvent(
-            key,
-            (value, unsubscribe) => {
-              const previousUnsubscribe = this.#contextSubscriptions.get(key);
-
-              // Call the old unsubscribe callback if it has changed. This probably
-              // means we have a new provider.
-              if (previousUnsubscribe !== unsubscribe) {
-                previousUnsubscribe?.();
-              }
-
-              const decoded = decode(value, decoder);
-              this.#contextSubscriptions.set(key, unsubscribe);
-
-              if (Result$isOk(decoded)) {
-                this.dispatch(Result$Ok$0(decoded), true);
-              }
-            },
-            true,
-          ),
-        );
-
+        this.#runtime.subscribe(key, decoder);
         requested.add(key);
       });
     }
 
     #unsubscribeContexts() {
-      for (const [_, unsubscribe] of this.#contextSubscriptions) {
-        unsubscribe?.();
-      }
-
-      this.#contextSubscriptions.clear();
+      this.#runtime.unsubscribeAll();
     }
 
     async #adoptStyleSheets() {

--- a/src/lustre/runtime/client/runtime.ffi.mjs
+++ b/src/lustre/runtime/client/runtime.ffi.mjs
@@ -8,6 +8,7 @@ import { Reconciler } from "../../vdom/reconciler.ffi.mjs";
 import { virtualise } from "../../vdom/virtualise.ffi.mjs";
 import { isEqual } from "../../internals/equals.ffi.mjs";
 import { append, iterate } from "../../internals/list.ffi.mjs";
+import { run as decode } from "../../../../gleam_stdlib/gleam/dynamic/decode.mjs";
 
 //
 
@@ -161,6 +162,57 @@ export class Runtime {
     }
   }
 
+  subscribe(key, decoder) {
+    // An empty key is not valid so we skip over any of those.
+    if (!key) return;
+
+    // If we were previously subscribed to this context, we should unsubscribe
+    // before before subscribing again with the new decoder.
+    this.#contextSubscriptions.get(key)?.();
+
+    const target = this.root.host ?? this.root;
+
+    target.dispatchEvent(
+      new ContextRequestEvent(
+        key,
+        (value, unsubscribe) => {
+          const previousUnsubscribe = this.#contextSubscriptions.get(key);
+
+          // Call the old unsubscribe callback if it has changed. This probably
+          // means we have a new provider.
+          if (previousUnsubscribe !== unsubscribe) {
+            previousUnsubscribe?.();
+          }
+
+          const decoded = decode(value, decoder);
+          this.#contextSubscriptions.set(key, unsubscribe);
+
+          if (Result$isOk(decoded)) {
+            this.dispatch(Result$Ok$0(decoded), true);
+          }
+        },
+        true,
+      )
+    );
+  }
+
+  unsubscribe(key) {
+    const unsubscribe = this.#contextSubscriptions.get(key);
+
+    if (unsubscribe) {
+      unsubscribe();
+      this.#contextSubscriptions.delete(key);
+    }
+  }
+
+  unsubscribeAll() {
+    for (const [_, unsubscribe] of this.#contextSubscriptions) {
+      unsubscribe?.();
+    }
+
+    this.#contextSubscriptions.clear();
+  }
+
   // PRIVATE API ---------------------------------------------------------------
 
   #model;
@@ -171,6 +223,7 @@ export class Runtime {
   #cache;
   #reconciler;
   #contexts = new Map();
+  #contextSubscriptions = new Map();
 
   #shouldQueue = false;
   #queue = [];
@@ -185,6 +238,8 @@ export class Runtime {
     select: () => {},
     root: () => this.root,
     provide: (key, value) => this.provide(key, value),
+    subscribe: (key, decoder) => this.subscribe(key, decoder),
+    unsubscribe: (key) => this.unsubscribe(key),
   };
 
   #scheduleRender(shouldFlush = false) {

--- a/src/lustre/runtime/client/server_component.ffi.mjs
+++ b/src/lustre/runtime/client/server_component.ffi.mjs
@@ -43,7 +43,7 @@ export class ServerComponent extends HTMLElement {
   #connected = false;
   #changedAttributesQueue = [];
   #contexts = new Map();
-  #contextSubscriptions = new Set();
+  #contextSubscriptions = new Map();
 
   #observer = new MutationObserver((mutations) => {
     const attributes = [];
@@ -269,7 +269,7 @@ export class ServerComponent extends HTMLElement {
       }
 
       case subscribe_kind: {
-        this.subscribe(data.key, null);
+        this.subscribe(data.key);
         break;
       }
 
@@ -332,7 +332,8 @@ export class ServerComponent extends HTMLElement {
           value,
         });
 
-        this.#contextSubscriptions.add(unsubscribe);
+        this.#contextSubscriptions.get(key)?.();
+        this.#contextSubscriptions.set(unsubscribe);
       }),
     );
   }
@@ -438,7 +439,7 @@ export class ServerComponent extends HTMLElement {
     const data = {};
 
     // For events emit but other Lustre components, we know it's always safe to
-    // include the entire `detail` property as-is. 
+    // include the entire `detail` property as-is.
     if (event.isLustreEvent) {
       include.push("detail");
     }

--- a/src/lustre/runtime/client/server_component.ffi.mjs
+++ b/src/lustre/runtime/client/server_component.ffi.mjs
@@ -15,6 +15,8 @@ import {
   reconcile_kind,
   emit_kind,
   provide_kind,
+  subscribe_kind,
+  unsubscribe_kind,
   attribute_changed_kind,
   property_changed_kind,
   event_fired_kind,
@@ -201,17 +203,7 @@ export class ServerComponent extends HTMLElement {
         }
 
         for (const key of [...new Set(data.requested_contexts)]) {
-          this.dispatchEvent(
-            new ContextRequestEvent(key, (value, unsubscribe) => {
-              this.#transport?.send({
-                kind: context_provided_kind,
-                key,
-                value,
-              });
-
-              this.#contextSubscriptions.add(unsubscribe);
-            }),
-          );
+          this.subscribe(key);
         }
 
         if (messages.length) {
@@ -275,18 +267,23 @@ export class ServerComponent extends HTMLElement {
         this.provide(data.key, data.value);
         break;
       }
+
+      case subscribe_kind: {
+        this.subscribe(data.key, null);
+        break;
+      }
+
+      case unsubscribe_kind: {
+        this.unsubscribe(data.key);
+        break;
+      }
     }
   }
 
   //
 
   disconnectedCallback() {
-    // Clean up any context subscriptions
-    for (const unsubscribe of this.#contextSubscriptions) {
-      unsubscribe();
-    }
-
-    this.#contextSubscriptions.clear();
+    this.unsubscribeAll();
 
     // Close the transport connection
     if (this.#transport) {
@@ -321,6 +318,36 @@ export class ServerComponent extends HTMLElement {
         subscriber(value, unsubscribe);
       }
     }
+  }
+
+  subscribe(key) {
+    if (!key) return;
+
+    this.#contextSubscriptions.get(key)?.();
+    this.dispatchEvent(
+      new ContextRequestEvent(key, (value, unsubscribe) => {
+        this.#transport?.send({
+          kind: context_provided_kind,
+          key,
+          value,
+        });
+
+        this.#contextSubscriptions.add(unsubscribe);
+      }),
+    );
+  }
+
+  unsubscribe(key) {
+    this.#contextSubscriptions.get(key)?.();
+    this.#contextSubscriptions.delete(key);
+  }
+
+  unsubscribeAll() {
+    for (const [_, unsubscribe] of this.#contextSubscriptions) {
+      unsubscribe?.();
+    }
+
+    this.#contextSubscriptions.clear();
   }
 
   #getCsrfToken() {

--- a/src/lustre/runtime/server/runtime.ffi.mjs
+++ b/src/lustre/runtime/server/runtime.ffi.mjs
@@ -22,6 +22,10 @@ import {
   Message$isEffectEmitEvent,
   Message$EffectProvidedValue,
   Message$isEffectProvidedValue,
+  Message$EffectRequestedContextSubscription,
+  Message$isEffectRequestedContextSubscription,
+  Message$EffectRemovedContextSubscription,
+  Message$isEffectRemovedContextSubscription,
   //
   Message$isSystemRequestedShutdown,
 } from "./runtime.mjs";
@@ -127,6 +131,16 @@ export class Runtime {
 
       this.#providers = Dict.insert(this.#providers, key, value);
       this.broadcast(Transport.provide(key, value));
+    } else if (Message$isEffectRequestedContextSubscription(message)) {
+      const { key, decoder } = message;
+
+      this.broadcast(Transport.subscribe(key));
+      this.#config.contexts = Dict.insert(this.#config.contexts, key, decoder);
+    } else if (Message$isEffectRemovedContextSubscription(message)) {
+      const { key } = message;
+      
+      this.broadcast(Transport.unsubscribe(key));
+      this.#config.contexts = Dict.delete(this.#config.contexts, key);
     } else if (Message$isSystemRequestedShutdown(message)) {
       this.#model = null;
       this.#update = null;
@@ -245,9 +259,21 @@ export class Runtime {
     const internals = () => undefined;
     const provide = (key, value) =>
       this.send(Message$EffectProvidedValue(key, value));
+    const subscribe = (key, decoder) => 
+      this.send(Message$EffectRequestedContextSubscription(key, decoder));
+    const unsubscribe = (key) => 
+      this.send(Message$EffectRemovedContextSubscription(key));
 
     globalThis.queueMicrotask(() => {
-      Effect.perform(effect, dispatch, emit, select, internals, provide);
+      Effect.perform(effect, 
+        dispatch, 
+        emit, 
+        select, 
+        internals, 
+        provide, 
+        subscribe, 
+        unsubscribe
+      );
     });
   }
 }

--- a/src/lustre/runtime/server/runtime.gleam
+++ b/src/lustre/runtime/server/runtime.gleam
@@ -147,6 +147,8 @@ pub type Message(message) {
   EffectDispatchedMessage(message: message)
   EffectEmitEvent(name: String, data: Json)
   EffectProvidedValue(key: String, value: Json)
+  EffectRequestedContextSubscription(key: String, decoder: Decoder(message))
+  EffectRemovedContextSubscription(key: String)
   //
   MonitorReportedDown(monitor: Monitor)
   //
@@ -312,6 +314,32 @@ fn loop(
       actor.continue(State(..state, providers:))
     }
 
+    EffectRequestedContextSubscription(key:, decoder:) -> {
+      let message = transport.subscribe(key)
+      let _ = broadcast(state.subscribers, state.callbacks, message)
+
+      let config =
+        Config(
+          ..state.config,
+          contexts: dict.insert(state.config.contexts, key, decoder),
+        )
+
+      actor.continue(State(..state, config:))
+    }
+
+    EffectRemovedContextSubscription(key:) -> {
+      let message = transport.unsubscribe(key)
+      let _ = broadcast(state.subscribers, state.callbacks, message)
+
+      let config =
+        Config(
+          ..state.config,
+          contexts: dict.delete(state.config.contexts, key),
+        )
+
+      actor.continue(State(..state, config:))
+    }
+
     MonitorReportedDown(monitor:) -> {
       let subscribers =
         dict.filter(state.subscribers, fn(_, m) { m != monitor })
@@ -432,6 +460,10 @@ fn handle_effect(
   let dispatch = fn(message) { send(EffectDispatchedMessage(message:)) }
   let emit = fn(name, data) { send(EffectEmitEvent(name:, data:)) }
   let provide = fn(key, value) { send(EffectProvidedValue(key:, value:)) }
+  let subscribe = fn(key, decoder) {
+    send(EffectRequestedContextSubscription(key:, decoder:))
+  }
+  let unsubscribe = fn(key) { send(EffectRemovedContextSubscription(key:)) }
 
   let select = fn(selector) {
     selector
@@ -442,7 +474,16 @@ fn handle_effect(
 
   let internals = fn() { dynamic.nil() }
 
-  effect.perform(effect, dispatch, emit, select, internals, provide)
+  effect.perform(
+    effect,
+    dispatch,
+    emit,
+    select,
+    internals,
+    provide,
+    subscribe,
+    unsubscribe,
+  )
 }
 
 @target(erlang)

--- a/src/lustre/runtime/transport.gleam
+++ b/src/lustre/runtime/transport.gleam
@@ -25,6 +25,8 @@ pub type ClientMessage(message) {
   Reconcile(kind: Int, patch: Patch(message), memos: Memos(message))
   Emit(kind: Int, name: String, data: Json)
   Provide(kind: Int, key: String, value: Json)
+  Subscribe(kind: Int, key: String)
+  Unsubscribe(kind: Int, key: String)
 }
 
 pub type ServerMessage {
@@ -81,6 +83,18 @@ pub const provide_kind: Int = 3
 
 pub fn provide(key: String, value: Json) -> ClientMessage(message) {
   Provide(kind: provide_kind, key:, value:)
+}
+
+pub const subscribe_kind: Int = 4
+
+pub fn subscribe(key: String) -> ClientMessage(message) {
+  Subscribe(kind: subscribe_kind, key:)
+}
+
+pub const unsubscribe_kind: Int = 5
+
+pub fn unsubscribe(key: String) -> ClientMessage(message) {
+  Unsubscribe(kind: unsubscribe_kind, key:)
 }
 
 pub const attribute_changed_kind: Int = 0
@@ -152,6 +166,8 @@ pub fn client_message_to_json(message: ClientMessage(message)) -> Json {
     Reconcile(kind:, patch:, memos:) -> reconcile_to_json(kind, patch, memos)
     Emit(kind:, name:, data:) -> emit_to_json(kind, name, data)
     Provide(kind:, key:, value:) -> provide_to_json(kind, key, value)
+    Subscribe(kind:, key:) -> subscribe_to_json(kind, key)
+    Unsubscribe(kind:, key:) -> unsubscribe_to_json(kind, key)
   }
 }
 
@@ -205,6 +221,20 @@ fn provide_to_json(kind: Int, key: String, value: Json) -> Json {
     #("kind", json.int(kind)),
     #("key", json.string(key)),
     #("value", value),
+  ])
+}
+
+fn subscribe_to_json(kind: Int, key: String) -> Json {
+  json.object([
+    #("kind", json.int(kind)),
+    #("key", json.string(key)),
+  ])
+}
+
+fn unsubscribe_to_json(kind: Int, key: String) -> Json {
+  json.object([
+    #("kind", json.int(kind)),
+    #("key", json.string(key)),
   ])
 }
 


### PR DESCRIPTION
A few versions back we implemented the [WCCG Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md) by adding the `effect.provide` effect and a `component.on_context_change` component option. This allowed any Lustre application to provide context values under a specific key, and for any Lustre _component_ (server or client) to subscribe to changes to those values and dispatch messages.

Because this is a web component protocol we overlooked the fact that applications might want to subscribe to context values too! The most-compelling scenario for this is when a client SPA is rendered in a server component `<slot>`, enabling a "store pattern" that let's the app subscribe to backend data without the need for an explicit API.

This PR deprecates `component.on_context_change` entirely in favour of two new effects:

- `effect.subscribe`
- `effect.unsubscribe`

As context _unsubscription_ is new behaviour, we needed to decide what should happen to existing component context subscriptions are unsubscribed from and then the component is subsequently unmounted and remounted to the DOM. We decided that **removed subscriptions should not be re-added when the component reconnects**.