### PR TITLE
Update the documentation on the update in mist

### DIFF
--- a/pages/guide/05-server-side-rendering.md
+++ b/pages/guide/05-server-side-rendering.md
@@ -48,7 +48,7 @@ pub fn main() {
     }
     |> mist.new
     |> mist.port(3000)
-    |> mist.start_http
+    |> mist.start
 
   process.sleep_forever()
 }

--- a/pages/guide/07-full-stack-deployments.md
+++ b/pages/guide/07-full-stack-deployments.md
@@ -137,7 +137,7 @@ let port = get_port()
 mist.new(handler)
 |> mist.bind(host)
 |> mist.port(port)
-|> mist.start_http
+|> mist.start
 ```
 
 ## Deploying to Fly.io


### PR DESCRIPTION
The sample code failed to compile.

According to https://github.com/rawhat/mist/pull/71, `mist.start_http` has been replaced with `mist.start`.