### PR TITLE
Fix JS dict delete export in server runtime

### DIFF
--- a/src/lustre/runtime/server/runtime.ffi.mjs
+++ b/src/lustre/runtime/server/runtime.ffi.mjs
@@ -140,7 +140,7 @@ export class Runtime {
       const { key } = message;
       
       this.broadcast(Transport.unsubscribe(key));
-      this.#config.contexts = Dict.delete(this.#config.contexts, key);
+      this.#config.contexts = Dict.delete$(this.#config.contexts, key);
     } else if (Message$isSystemRequestedShutdown(message)) {
       this.#model = null;
       this.#update = null;


### PR DESCRIPTION
This fixes the server runtime JS FFI to call `Dict.delete$` instead of `Dict.delete`.
`gleam_stdlib` exports Gleam functions with JavaScript-reserved names using an escaped suffix, so `gleam/dict.delete` is emitted as `delete$`.

When bundling Lustre's JavaScript output, esbuild reports:
```text
▲ [WARNING] Import "delete" will always be undefined because there is no matching export in "build/dev/ja
vascript/gleam_stdlib/gleam/dict.mjs" [import-is-undefined]

    build/dev/javascript/lustre/lustre/runtime/server/runtime.ffi.mjs:143:35:
      143 │       this.#config.contexts = Dict.delete(this.#config.contexts, key);
          │                                    ~~~~~~
          ╵                                    delete$

  Did you mean to import "delete$" instead?

    build/dev/javascript/gleam_stdlib/gleam/dict.mjs:306:16:
      306 │ export function delete$(dict, key) {
          ╵                 ~~~~~~~

1 warning