### PR TITLE
Add example demonstrating element.map

### DIFF
--- a/examples/01-basics/07-element-map/README.md
+++ b/examples/01-basics/07-element-map/README.md
@@ -1,0 +1,1 @@
+# 01-basics/07-element-map

--- a/examples/01-basics/07-element-map/gleam.toml
+++ b/examples/01-basics/07-element-map/gleam.toml
@@ -1,0 +1,10 @@
+name = "app"
+version = "1.0.0"
+dev-dependencies = { lustre_dev_tools = ">= 2.0.0 and < 3.0.0" }
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+lustre = { path = "../../../" }
+
+[tools.lustre.html]
+title = "01-basics/07-element-map"

--- a/examples/01-basics/07-element-map/src/app.css
+++ b/examples/01-basics/07-element-map/src/app.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/examples/01-basics/07-element-map/src/app.gleam
+++ b/examples/01-basics/07-element-map/src/app.gleam
@@ -1,0 +1,62 @@
+// IMPORTS ---------------------------------------------------------------------
+
+import counter
+import lustre
+import lustre/attribute
+import lustre/element.{type Element}
+import lustre/element/html
+
+// MAIN ------------------------------------------------------------------------
+
+pub fn main() {
+  let app = lustre.simple(init, update, view)
+
+  // When starting a Lustre app, you can pass in initial data as "flags" to your
+  // application. Because the pieces of your app are supposed to be *pure*, flags
+  // are a good opportunity to pass in initial data from side effects such as
+  // randomness or HTTP requests that you want to have immediately available.
+  let assert Ok(_) = lustre.start(app, "#app", Nil)
+
+  Nil
+}
+
+// MODEL -----------------------------------------------------------------------
+
+/// For this example, our main "app" doesn't need any state or functionality of
+/// its own. Instead it manages the state of another gleam module, delegating 
+/// init, update and view functions to the other module. This approach
+/// allows for separating state among modules without needing full web
+/// components. It demonstrates how to make an Element(OtherMsg) returned from
+/// the other module's view callback compatible in a generic way with a parent 
+/// module using element.map
+type Model {
+  Model(counter: counter.Model)
+}
+
+fn init(_) -> Model {
+  Model(counter: counter.init(0))
+}
+
+// UPDATE ----------------------------------------------------------------------
+
+type Msg {
+  CounterUpdated(counter.Msg)
+}
+
+fn update(model: Model, msg: Msg) -> Model {
+  case msg {
+    CounterUpdated(counter_msg) ->
+      Model(counter: counter.update(model.counter, counter_msg))
+  }
+}
+
+// VIEW ------------------------------------------------------------------------
+
+fn view(model: Model) -> Element(Msg) {
+  html.div([attribute.class("p-32 mx-auto w-full max-w-2xl")], [
+    // counter.view returns an Element parameterised on the Msg type declared 
+    // in the counter module. element.map/1 here makes it compatible with our
+    // Msg type
+    counter.view(model.counter) |> element.map(CounterUpdated),
+  ])
+}

--- a/examples/01-basics/07-element-map/src/counter.gleam
+++ b/examples/01-basics/07-element-map/src/counter.gleam
@@ -1,0 +1,62 @@
+// IMPORTS ---------------------------------------------------------------------
+
+import gleam/int
+import lustre/attribute
+import lustre/element.{type Element}
+import lustre/element/html
+import lustre/event
+
+// MODEL -----------------------------------------------------------------------
+
+/// The state for our module must be public as it is managed by the update loop
+/// of the parent module
+pub type Model =
+  Int
+
+pub fn init(init_value) -> Model {
+  init_value
+}
+
+// UPDATE ----------------------------------------------------------------------
+
+/// Just like our `Model`, the `Msg` type is public and needs to be
+/// handled by the parent app. This makes it a bit less convenient than using 
+/// components but it does allow us to encapsulate complex functionality and rich
+/// user interaction without full web components.
+///
+pub type Msg {
+  UserClickedIncrement
+  UserClickedDecrement
+}
+
+pub fn update(model: Model, msg: Msg) -> Model {
+  case msg {
+    UserClickedIncrement -> model + 1
+    UserClickedDecrement -> model - 1
+  }
+}
+
+// VIEW ------------------------------------------------------------------------
+
+pub fn view(model: Model) -> Element(Msg) {
+  let count = int.to_string(model)
+
+  html.div([attribute.class("py-4 flex items-center gap-2")], [
+    view_button(label: "-", on_click: UserClickedDecrement),
+    html.p([attribute.class("flex-1")], [html.text("Count: "), html.text(count)]),
+    view_button(label: "+", on_click: UserClickedIncrement),
+  ])
+}
+
+fn view_button(
+  label label: String,
+  on_click handle_click: msg,
+) -> Element(msg) {
+  html.button(
+    [
+      attribute.class("bg-blue-500 text-white w-12 py-1 rounded"),
+      event.on_click(handle_click),
+    ],
+    [html.text(label)],
+  )
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,9 @@ or rendering elements that can handle events.
 - [`06-flags`](https://github.com/lustre-labs/lustre/tree/main/examples/01-basics/06-flags) shows
   how to pass initialization data to your Lustre application.
 
+- [`07-element-map`](https://github.com/lustre-labs/lustre/tree/main/examples/01-basics/07-element-map) shows
+  a way to manage state in a sub module of a Lustre application without using a component
+
 ## 02-inputs
 
 Handling inputs and interactive elements is an important part of any application!


### PR DESCRIPTION
It took me quite a while to figure out delegating state to another module without building a web component. The trick turned out to be element.map so the sub module doesn't need to know the type of the parent application Msg

I offer this example as I would have found it useful. Feel free to edit to taste or move it around, or simply reject.

I'm not super happy that my descriptions match house style so some help there would be good.

/Sean