### PR TITLE
Add code documentation comments to HTML elements taken from whatwg

### DIFF
--- a/src/lustre/element/html.gleam
+++ b/src/lustre/element/html.gleam
@@ -7,7 +7,10 @@ import lustre/internals/constants
 
 // HTML ELEMENTS: MAIN ROOT ----------------------------------------------------
 
+/// Represents the root of an HTML document; every other element in the document
+/// is a descendant of it.
 ///
+/// <https://html.spec.whatwg.org/multipage/semantics.html#the-html-element>
 pub fn html(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -15,18 +18,30 @@ pub fn html(
   element("html", attrs, children)
 }
 
+/// Renders a plain text node in the DOM, without any surrounding element or
+/// namespace. Text nodes are leaves in the element tree and cannot have
+/// attributes or children of their own.
+///
+/// <https://developer.mozilla.org/en-US/docs/Web/API/Text>
 pub fn text(content: String) -> Element(message) {
   element.text(content)
 }
 
 // HTML ELEMENTS: DOCUMENT METADATA --------------------------------------------
 
+/// Lets authors specify the document's base URL, and optionally a default
+/// navigable target name, for use when resolving relative URLs and following
+/// links.
 ///
+/// <https://html.spec.whatwg.org/multipage/semantics.html#the-base-element>
 pub fn base(attrs: List(Attribute(message))) -> Element(message) {
   element("base", attrs, constants.empty_list)
 }
 
+/// Contains the collection of a document's metadata elements, such as its
+/// title, scripts, and style sheets.
 ///
+/// <https://html.spec.whatwg.org/multipage/semantics.html#the-head-element>
 pub fn head(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -34,22 +49,34 @@ pub fn head(
   element("head", attrs, children)
 }
 
+/// Lets authors link their document to other resources, such as style sheets or
+/// icons, by declaring one or more relationships to those resources.
 ///
+/// <https://html.spec.whatwg.org/multipage/semantics.html#the-link-element>
 pub fn link(attrs: List(Attribute(message))) -> Element(message) {
   element("link", attrs, constants.empty_list)
 }
 
+/// Represents document-level metadata, pragma directives, or a character
+/// encoding declaration, depending on which attribute is used to specify it.
 ///
+/// <https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element>
 pub fn meta(attrs: List(Attribute(message))) -> Element(message) {
   element("meta", attrs, constants.empty_list)
 }
 
+/// Allows authors to embed CSS style information directly in the document.
 ///
+/// <https://html.spec.whatwg.org/multipage/semantics.html#the-style-element>
 pub fn style(attrs: List(Attribute(message)), css: String) -> Element(message) {
   element.unsafe_raw_html("", "style", attrs, css)
 }
 
+/// Represents the document's title or name, which authors should choose so that
+/// it identifies the document even out of context, such as in a browser history
+/// or search results.
 ///
+/// <https://html.spec.whatwg.org/multipage/semantics.html#the-title-element>
 pub fn title(
   attrs: List(Attribute(message)),
   content: String,
@@ -59,7 +86,10 @@ pub fn title(
 
 // HTML ELEMENTS: SECTIONING ROOT -----------------------------------------------
 
+/// Represents the contents of the document; a conforming document has exactly
+/// one body element.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-body-element>
 pub fn body(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -69,7 +99,9 @@ pub fn body(
 
 // HTML ELEMENTS: CONTENT SECTIONING -------------------------------------------
 
+/// Represents the contact information for its nearest article or body ancestor.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-address-element>
 pub fn address(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -77,7 +109,11 @@ pub fn address(
   element("address", attrs, children)
 }
 
+/// Represents a complete, self-contained composition that is in principle
+/// independently distributable or reusable, such as a forum post, magazine
+/// article, or blog entry.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-article-element>
 pub fn article(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -85,7 +121,11 @@ pub fn article(
   element("article", attrs, children)
 }
 
+/// Represents a section of a page whose content is only tangentially related to
+/// the content around it, and which could be considered separate from that
+/// content.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-aside-element>
 pub fn aside(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -93,7 +133,11 @@ pub fn aside(
   element("aside", attrs, children)
 }
 
+/// Represents a footer for its nearest ancestor sectioning content, typically
+/// containing information about the section such as who wrote it or copyright
+/// data.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-footer-element>
 pub fn footer(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -101,7 +145,10 @@ pub fn footer(
   element("footer", attrs, children)
 }
 
+/// Represents a group of introductory or navigational aids, such as a heading,
+/// a logo, or a search form.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-header-element>
 pub fn header(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -109,7 +156,10 @@ pub fn header(
   element("header", attrs, children)
 }
 
+/// Represents a heading for its section, with the heading level given by the
+/// number in the element's name.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements>
 pub fn h1(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -117,7 +167,10 @@ pub fn h1(
   element("h1", attrs, children)
 }
 
+/// Represents a heading for its section, with the heading level given by the
+/// number in the element's name.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements>
 pub fn h2(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -125,7 +178,10 @@ pub fn h2(
   element("h2", attrs, children)
 }
 
+/// Represents a heading for its section, with the heading level given by the
+/// number in the element's name.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements>
 pub fn h3(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -133,7 +189,10 @@ pub fn h3(
   element("h3", attrs, children)
 }
 
+/// Represents a heading for its section, with the heading level given by the
+/// number in the element's name.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements>
 pub fn h4(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -141,7 +200,10 @@ pub fn h4(
   element("h4", attrs, children)
 }
 
+/// Represents a heading for its section, with the heading level given by the
+/// number in the element's name.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements>
 pub fn h5(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -149,7 +211,10 @@ pub fn h5(
   element("h5", attrs, children)
 }
 
+/// Represents a heading for its section, with the heading level given by the
+/// number in the element's name.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements>
 pub fn h6(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -157,7 +222,11 @@ pub fn h6(
   element("h6", attrs, children)
 }
 
+/// Represents a heading together with related content, grouping a heading
+/// element with one or more p elements that hold a subheading, alternative
+/// title, or tagline.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-hgroup-element>
 pub fn hgroup(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -165,7 +234,11 @@ pub fn hgroup(
   element("hgroup", attrs, children)
 }
 
+/// Represents the dominant contents of the document, excluding content that is
+/// repeated across a set of documents such as navigation links, headers, and
+/// footers.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element>
 pub fn main(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -173,7 +246,10 @@ pub fn main(
   element("main", attrs, children)
 }
 
+/// Represents a section of a page whose purpose is to provide navigation links,
+/// either within the page or to other pages.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-nav-element>
 pub fn nav(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -181,7 +257,10 @@ pub fn nav(
   element("nav", attrs, children)
 }
 
+/// Represents a generic section of a document or application, being a thematic
+/// grouping of content that typically has a heading.
 ///
+/// <https://html.spec.whatwg.org/multipage/sections.html#the-section-element>
 pub fn section(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -189,7 +268,10 @@ pub fn section(
   element("section", attrs, children)
 }
 
+/// Represents a part of a document containing a form, controls, or other
+/// content related to performing a search or filtering operation.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element>
 pub fn search(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -199,7 +281,10 @@ pub fn search(
 
 // HTML ELEMENTS: TEXT CONTENT -------------------------------------------------
 
+/// Represents a section that is quoted from another source, whose address may
+/// be given using the cite attribute.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element>
 pub fn blockquote(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -207,7 +292,10 @@ pub fn blockquote(
   element("blockquote", attrs, children)
 }
 
+/// Represents the description, definition, or value part of a name-value group
+/// in a description list.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element>
 pub fn dd(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -215,7 +303,10 @@ pub fn dd(
   element("dd", attrs, children)
 }
 
+/// Has no special meaning of its own; it simply represents its children and is
+/// useful for applying styling or scripting hooks to a group of elements.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element>
 pub fn div(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -223,7 +314,10 @@ pub fn div(
   element("div", attrs, children)
 }
 
+/// Represents an association list of zero or more name-value groups, each
+/// consisting of terms and their descriptions.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element>
 pub fn dl(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -231,7 +325,10 @@ pub fn dl(
   element("dl", attrs, children)
 }
 
+/// Represents the term, or name, part of a name-value group in a description
+/// list.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element>
 pub fn dt(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -239,7 +336,10 @@ pub fn dt(
   element("dt", attrs, children)
 }
 
+/// Represents a caption or legend for the rest of the contents of its parent
+/// figure element, if it has one.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element>
 pub fn figcaption(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -247,7 +347,11 @@ pub fn figcaption(
   element("figcaption", attrs, children)
 }
 
+/// Represents some flow content, optionally with a caption, that is self-
+/// contained and would typically be referenced as a single unit from the
+/// document's main flow.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-figure-element>
 pub fn figure(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -255,12 +359,18 @@ pub fn figure(
   element("figure", attrs, children)
 }
 
+/// Represents a paragraph-level thematic break, such as a scene change in a
+/// story or a transition to a new topic within a section.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-hr-element>
 pub fn hr(attrs: List(Attribute(message))) -> Element(message) {
   element("hr", attrs, constants.empty_list)
 }
 
+/// Represents an item in a list; its parent element determines what kind of
+/// list it belongs to, such as an ordered list, unordered list, or menu.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element>
 pub fn li(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -268,7 +378,10 @@ pub fn li(
   element("li", attrs, children)
 }
 
+/// A semantic alternative to ul used to represent a toolbar consisting of an
+/// unordered list of commands.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-menu-element>
 pub fn menu(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -276,7 +389,10 @@ pub fn menu(
   element("menu", attrs, children)
 }
 
+/// Represents a list of items where the order is meaningful, such that
+/// rearranging the items would change the meaning of the document.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element>
 pub fn ol(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -284,7 +400,10 @@ pub fn ol(
   element("ol", attrs, children)
 }
 
+/// Represents a paragraph, understood as a structural rather than a purely
+/// visual unit of content.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element>
 pub fn p(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -292,7 +411,10 @@ pub fn p(
   element("p", attrs, children)
 }
 
+/// Represents a block of preformatted text, in which structure is conveyed
+/// through typographic conventions rather than markup.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element>
 pub fn pre(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -300,7 +422,10 @@ pub fn pre(
   element("pre", attrs, children)
 }
 
+/// Represents a list of items where the order is not meaningful, such that
+/// rearranging the items would not materially change the document's meaning.
 ///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element>
 pub fn ul(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -310,7 +435,11 @@ pub fn ul(
 
 // HTML ELEMENTS: INLINE TEXT SEMANTICS ----------------------------------------
 
+/// Together with an href attribute, creates a hyperlink to web pages, files,
+/// email addresses, or any other kind of URL; without an href, it represents a
+/// placeholder for where a link might otherwise be.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element>
 pub fn a(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -318,7 +447,10 @@ pub fn a(
   element("a", attrs, children)
 }
 
+/// Represents an abbreviation or acronym, optionally with its expansion given
+/// by the title attribute.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-abbr-element>
 pub fn abbr(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -326,7 +458,10 @@ pub fn abbr(
   element("abbr", attrs, children)
 }
 
+/// Draws the reader's attention to text without conveying any extra importance,
+/// for instance keywords in a summary or product names in a review.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element>
 pub fn b(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -334,7 +469,11 @@ pub fn b(
   element("b", attrs, children)
 }
 
+/// Isolates a run of text that might be formatted in a different direction from
+/// the surrounding text, useful when embedding user-generated content of
+/// unknown directionality.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdi-element>
 pub fn bdi(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -342,7 +481,10 @@ pub fn bdi(
   element("bdi", attrs, children)
 }
 
+/// Overrides the current directionality of text, so that its contents are
+/// rendered in the explicitly given direction.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element>
 pub fn bdo(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -350,12 +492,18 @@ pub fn bdo(
   element("bdo", attrs, children)
 }
 
+/// Represents a line break within text content, such as in a poem or a mailing
+/// address, where the division between lines is significant.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element>
 pub fn br(attrs: List(Attribute(message))) -> Element(message) {
   element("br", attrs, constants.empty_list)
 }
 
+/// Represents the title of a work, such as a book, play, song, film, or paper,
+/// whether being cited in detail or merely mentioned in passing.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-cite-element>
 pub fn cite(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -363,7 +511,10 @@ pub fn cite(
   element("cite", attrs, children)
 }
 
+/// Represents a fragment of computer code, such as an element name, filename,
+/// or a piece of a program.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element>
 pub fn code(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -371,7 +522,10 @@ pub fn code(
   element("code", attrs, children)
 }
 
+/// Links a piece of content with a machine-readable form of that content, given
+/// by the value attribute.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-data-element>
 pub fn data(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -379,7 +533,11 @@ pub fn data(
   element("data", attrs, children)
 }
 
+/// Represents the defining instance of a term, whose definition should be found
+/// among the contents of the nearest enclosing paragraph, description list
+/// group, or section.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element>
 pub fn dfn(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -387,7 +545,10 @@ pub fn dfn(
   element("dfn", attrs, children)
 }
 
+/// Represents stress emphasis of its contents, where the degree of stress is
+/// indicated by the number of ancestor em elements.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-em-element>
 pub fn em(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -395,7 +556,11 @@ pub fn em(
   element("em", attrs, children)
 }
 
+/// Represents a span of text set off from the surrounding text for some reason,
+/// such as idiomatic phrases, technical terms, or a shift in tone, without
+/// implying extra importance.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element>
 pub fn i(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -403,7 +568,10 @@ pub fn i(
   element("i", attrs, children)
 }
 
+/// Represents user input, typically keyboard input, though it can also
+/// represent other input such as voice commands.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-kbd-element>
 pub fn kbd(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -411,7 +579,10 @@ pub fn kbd(
   element("kbd", attrs, children)
 }
 
+/// Represents text that is marked or highlighted because of its relevance in
+/// the surrounding context, such as search terms in a quoted passage.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element>
 pub fn mark(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -419,7 +590,11 @@ pub fn mark(
   element("mark", attrs, children)
 }
 
+/// Represents some phrasing content quoted from another source, with quotation
+/// punctuation added automatically by the user agent's rendering rather than
+/// typed by the author.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-q-element>
 pub fn q(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -427,7 +602,10 @@ pub fn q(
   element("q", attrs, children)
 }
 
+/// Provides fallback parentheses for legacy user agents that do not support
+/// ruby annotations, wrapping around an rt element's content.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element>
 pub fn rp(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -435,7 +613,10 @@ pub fn rp(
   element("rp", attrs, children)
 }
 
+/// Marks the ruby text component of a ruby annotation, used to give the
+/// pronunciation, translation, or transliteration of the associated base text.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element>
 pub fn rt(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -443,7 +624,11 @@ pub fn rt(
   element("rt", attrs, children)
 }
 
+/// Allows one or more spans of text to be marked up with ruby annotations,
+/// short runs of text presented alongside the base text, primarily used in East
+/// Asian typography.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element>
 pub fn ruby(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -451,7 +636,10 @@ pub fn ruby(
   element("ruby", attrs, children)
 }
 
+/// Represents contents that are no longer accurate or no longer relevant, as
+/// distinct from document edits, for which the del element is used instead.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element>
 pub fn s(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -459,7 +647,10 @@ pub fn s(
   element("s", attrs, children)
 }
 
+/// Represents sample or quoted output from a computer program or other
+/// computing system.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-samp-element>
 pub fn samp(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -467,7 +658,10 @@ pub fn samp(
   element("samp", attrs, children)
 }
 
+/// Represents side comments such as small print, for instance disclaimers,
+/// caveats, or licensing information.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-small-element>
 pub fn small(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -475,7 +669,10 @@ pub fn small(
   element("small", attrs, children)
 }
 
+/// A generic container for phrasing content that does not itself represent
+/// anything, useful for grouping elements for styling or scripting purposes.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element>
 pub fn span(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -483,7 +680,10 @@ pub fn span(
   element("span", attrs, children)
 }
 
+/// Represents strong importance, seriousness, or urgency for its contents, with
+/// the degree given by the number of ancestor strong elements.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-strong-element>
 pub fn strong(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -491,7 +691,10 @@ pub fn strong(
   element("strong", attrs, children)
 }
 
+/// Specifies that its contents should be displayed as subscript, for
+/// typographical reasons such as chemical formulas or footnote markers.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements>
 pub fn sub(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -499,7 +702,10 @@ pub fn sub(
   element("sub", attrs, children)
 }
 
+/// Specifies that its contents should be displayed as superscript, for
+/// typographical reasons such as exponents or ordinal indicators.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements>
 pub fn sup(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -507,7 +713,11 @@ pub fn sup(
   element("sup", attrs, children)
 }
 
+/// Represents its contents along with a machine-readable equivalent given by
+/// the datetime attribute, restricted to dates, times, time zone offsets, and
+/// durations.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-time-element>
 pub fn time(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -515,7 +725,11 @@ pub fn time(
   element("time", attrs, children)
 }
 
+/// Represents a span of text with a non-textual annotation, such as marking it
+/// as a proper name in a language that conventionally does so, without implying
+/// any particular styling.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element>
 pub fn u(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -523,7 +737,11 @@ pub fn u(
   element("u", attrs, children)
 }
 
+/// Represents a variable, whether an actual variable in a mathematical
+/// expression or programming context, or simply a placeholder term used in
+/// prose.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element>
 pub fn var(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -531,19 +749,28 @@ pub fn var(
   element("var", attrs, children)
 }
 
+/// Represents a word break opportunity, a position at which the user agent may
+/// choose to break a line that would otherwise be inconveniently long.
 ///
+/// <https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element>
 pub fn wbr(attrs: List(Attribute(message))) -> Element(message) {
   element("wbr", attrs, constants.empty_list)
 }
 
 // HTML ELEMENTS: IMAGE AND MULTIMEDIA -----------------------------------------
 
+/// Represents either a hyperlink with some text and a corresponding clickable
+/// area on an image map, or a dead area that has no associated link.
 ///
+/// <https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element>
 pub fn area(attrs: List(Attribute(message))) -> Element(message) {
   element("area", attrs, constants.empty_list)
 }
 
+/// Represents a sound or audio stream, given by its source attribute or child
+/// source elements.
 ///
+/// <https://html.spec.whatwg.org/multipage/media.html#the-audio-element>
 pub fn audio(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -551,13 +778,21 @@ pub fn audio(
   element("audio", attrs, children)
 }
 
+/// Embeds an image into the document, represented either by the image data
+/// itself or, when unavailable, by the fallback text given in the alt
+/// attribute.
 ///
+/// <https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element>
 pub fn img(attrs: List(Attribute(message))) -> Element(message) {
   element("img", attrs, constants.empty_list)
 }
 
 /// Used with <area> elements to define an image map (a clickable link area).
+/// Together with any descendant area elements, defines an image map that can be
+/// associated with an img element; the map element itself represents its
+/// children.
 ///
+/// <https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element>
 pub fn map(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -565,12 +800,19 @@ pub fn map(
   element("map", attrs, children)
 }
 
+/// Lets authors specify explicit external timed text tracks, such as subtitles
+/// or captions, for a parent media element; it does not represent anything on
+/// its own.
 ///
+/// <https://html.spec.whatwg.org/multipage/media.html#the-track-element>
 pub fn track(attrs: List(Attribute(message))) -> Element(message) {
   element("track", attrs, constants.empty_list)
 }
 
+/// Used for playing videos or movies, and can also be used for audio content
+/// with the video's playback area repurposed to show captions.
 ///
+/// <https://html.spec.whatwg.org/multipage/media.html#the-video-element>
 pub fn video(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -580,22 +822,35 @@ pub fn video(
 
 // HTML ELEMENTS: EMBEDDED CONTENT ---------------------------------------------
 
+/// Provides an integration point for an external application or interactive
+/// content, such as a plugin.
 ///
+/// <https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element>
 pub fn embed(attrs: List(Attribute(message))) -> Element(message) {
   element("embed", attrs, constants.empty_list)
 }
 
+/// Represents its nested browsing context, embedding another HTML page within
+/// the current one.
 ///
+/// <https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element>
 pub fn iframe(attrs: List(Attribute(message))) -> Element(message) {
   element("iframe", attrs, constants.empty_list)
 }
 
+/// Represents an external resource, which, depending on its type, is treated as
+/// an image or as a nested browsing context.
 ///
+/// <https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element>
 pub fn object(attrs: List(Attribute(message))) -> Element(message) {
   element("object", attrs, constants.empty_list)
 }
 
+/// A container providing multiple sources for its contained img element,
+/// allowing the user agent to choose the most appropriate image based on screen
+/// density, viewport size, or format.
 ///
+/// <https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element>
 pub fn picture(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -603,19 +858,29 @@ pub fn picture(
   element("picture", attrs, children)
 }
 
+/// Enables the embedding of another HTML page within the current one to allow
+/// smoother navigation into new pages; an experimental element not (yet) part
+/// of the WHATWG HTML Standard.
 ///
+/// <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/portal>
 pub fn portal(attrs: List(Attribute(message))) -> Element(message) {
   element("portal", attrs, constants.empty_list)
 }
 
+/// Allows authors to specify multiple alternative source sets for an img
+/// element, or multiple alternative media resources for a video or audio
+/// element; it does not represent anything on its own.
 ///
+/// <https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element>
 pub fn source(attrs: List(Attribute(message))) -> Element(message) {
   element("source", attrs, constants.empty_list)
 }
 
 // HTML ELEMENTS: SVG AND MATHML -----------------------------------------------
 
+/// The top-level element for embedding MathML content into an HTML document.
 ///
+/// <https://developer.mozilla.org/en-US/docs/Web/MathML/Element/math>
 pub fn math(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -623,7 +888,9 @@ pub fn math(
   namespaced("http://www.w3.org/1998/Math/MathML", "math", attrs, children)
 }
 
+/// The top-level element for embedding SVG content into an HTML document.
 ///
+/// <https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg>
 pub fn svg(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -633,12 +900,18 @@ pub fn svg(
 
 // HTML ELEMENTS: SCRIPTING ----------------------------------------------------
 
+/// Provides scripts with a resolution-dependent bitmap canvas that can be used
+/// to render graphs, game graphics, art, or other images dynamically.
 ///
+/// <https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element>
 pub fn canvas(attrs: List(Attribute(message))) -> Element(message) {
   element("canvas", attrs, constants.empty_list)
 }
 
+/// Represents nothing if scripting is enabled, but defines alternative content
+/// to be used when scripting is disabled in the user's browser.
 ///
+/// <https://html.spec.whatwg.org/multipage/scripting.html#the-noscript-element>
 pub fn noscript(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -646,14 +919,19 @@ pub fn noscript(
   element("noscript", attrs, children)
 }
 
+/// Used to embed executable code or data, most commonly JavaScript.
 ///
+/// <https://html.spec.whatwg.org/multipage/scripting.html#the-script-element>
 pub fn script(attrs: List(Attribute(message)), js: String) -> Element(message) {
   element.unsafe_raw_html("", "script", attrs, js)
 }
 
 // HTML ELEMENTS: DEMARCATING EDITS ---------------------------------------------
 
+/// Represents a removal from the document, such as a deleted passage in a
+/// tracked-changes view.
 ///
+/// <https://html.spec.whatwg.org/multipage/edits.html#the-del-element>
 pub fn del(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -661,7 +939,10 @@ pub fn del(
   element.element("del", attrs, children)
 }
 
+/// Represents an addition to the document, such as an inserted passage in a
+/// tracked-changes view.
 ///
+/// <https://html.spec.whatwg.org/multipage/edits.html#the-ins-element>
 pub fn ins(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -671,7 +952,9 @@ pub fn ins(
 
 // HTML ELEMENTS: TABLE CONTENT ------------------------------------------------
 
+/// Represents the title of the table that is its parent, if it has one.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-caption-element>
 pub fn caption(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -679,12 +962,17 @@ pub fn caption(
   element.element("caption", attrs, children)
 }
 
+/// Represents one or more columns in the column group represented by its parent
+/// colgroup element.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-col-element>
 pub fn col(attrs: List(Attribute(message))) -> Element(message) {
   element.element("col", attrs, constants.empty_list)
 }
 
+/// Represents a group of one or more columns in its parent table element.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-colgroup-element>
 pub fn colgroup(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -692,7 +980,10 @@ pub fn colgroup(
   element.element("colgroup", attrs, children)
 }
 
+/// Represents data with more than one dimension, in the form of a table of rows
+/// and columns of cells.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-table-element>
 pub fn table(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -700,7 +991,10 @@ pub fn table(
   element.element("table", attrs, children)
 }
 
+/// Represents a block of rows that make up the body of data for its parent
+/// table element.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-tbody-element>
 pub fn tbody(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -708,7 +1002,9 @@ pub fn tbody(
   element.element("tbody", attrs, children)
 }
 
+/// Represents a data cell in a table.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-td-element>
 pub fn td(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -716,7 +1012,10 @@ pub fn td(
   element.element("td", attrs, children)
 }
 
+/// Represents the block of rows consisting of the column summaries for its
+/// parent table element.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-tfoot-element>
 pub fn tfoot(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -724,7 +1023,10 @@ pub fn tfoot(
   element.element("tfoot", attrs, children)
 }
 
+/// Represents a header cell in a table, applying to a set of cells determined
+/// by its scope attribute.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-th-element>
 pub fn th(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -732,7 +1034,10 @@ pub fn th(
   element.element("th", attrs, children)
 }
 
+/// Represents the block of rows consisting of the column labels and any
+/// ancillary non-header cells for its parent table element.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-thead-element>
 pub fn thead(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -740,7 +1045,9 @@ pub fn thead(
   element.element("thead", attrs, children)
 }
 
+/// Represents a row of cells in a table.
 ///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-tr-element>
 pub fn tr(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -750,7 +1057,10 @@ pub fn tr(
 
 // HTML ELEMENTS: FORMS --------------------------------------------------------
 
+/// Represents a button labeled by its contents, whose behavior when activated
+/// is controlled by its type attribute, such as submitting or resetting a form.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element>
 pub fn button(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -758,7 +1068,10 @@ pub fn button(
   element.element("button", attrs, children)
 }
 
+/// Represents a set of option elements giving predefined options to suggest to
+/// the user for another control, most commonly a text input.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-datalist-element>
 pub fn datalist(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -766,7 +1079,10 @@ pub fn datalist(
   element.element("datalist", attrs, children)
 }
 
+/// Represents a set of form controls, optionally grouped under a caption given
+/// by a child legend element.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element>
 pub fn fieldset(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -774,7 +1090,10 @@ pub fn fieldset(
   element.element("fieldset", attrs, children)
 }
 
+/// Represents a collection of form-associated elements, some of which can
+/// represent editable values that can be submitted to a server for processing.
 ///
+/// <https://html.spec.whatwg.org/multipage/forms.html#the-form-element>
 pub fn form(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -782,12 +1101,20 @@ pub fn form(
   element.element("form", attrs, children)
 }
 
+/// Represents a typed data field, usually with a form control to allow the user
+/// to edit that data, with the kind of control determined by its type
+/// attribute.
 ///
+/// <https://html.spec.whatwg.org/multipage/input.html#the-input-element>
 pub fn input(attrs: List(Attribute(message))) -> Element(message) {
   element.element("input", attrs, constants.empty_list)
 }
 
+/// Represents a caption for an item in a user interface, associated with a
+/// specific form control either through its for attribute or by containing the
+/// control directly.
 ///
+/// <https://html.spec.whatwg.org/multipage/forms.html#the-label-element>
 pub fn label(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -795,7 +1122,10 @@ pub fn label(
   element.element("label", attrs, children)
 }
 
+/// Represents a caption for the rest of the contents of its parent fieldset
+/// element, if it has one.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-legend-element>
 pub fn legend(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -803,7 +1133,10 @@ pub fn legend(
   element.element("legend", attrs, children)
 }
 
+/// Represents a scalar measurement within a known range, or a fractional value,
+/// such as disk usage or the relevance of a search result.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element>
 pub fn meter(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -811,7 +1144,10 @@ pub fn meter(
   element.element("meter", attrs, children)
 }
 
+/// Represents a group of option elements with a common label, used to organize
+/// the choices offered by a select element.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element>
 pub fn optgroup(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -819,7 +1155,10 @@ pub fn optgroup(
   element.element("optgroup", attrs, children)
 }
 
+/// Represents an option in a select element, or as part of a list of
+/// suggestions offered by a datalist element.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element>
 pub fn option(
   attrs: List(Attribute(message)),
   label: String,
@@ -827,7 +1166,10 @@ pub fn option(
   element.element("option", attrs, [element.text(label)])
 }
 
+/// Represents the result of a calculation performed by the page, or the result
+/// of a user action, typically updated via script.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element>
 pub fn output(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -835,7 +1177,10 @@ pub fn output(
   element.element("output", attrs, children)
 }
 
+/// Represents the completion progress of a task, whether a determinate task
+/// with a known amount of work still to do, or an indeterminate one.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element>
 pub fn progress(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -843,7 +1188,10 @@ pub fn progress(
   element.element("progress", attrs, children)
 }
 
+/// Represents a control for selecting one or more options from a set, rendered
+/// as a drop-down box or a scrolling list box.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element>
 pub fn select(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -851,7 +1199,10 @@ pub fn select(
   element.element("select", attrs, children)
 }
 
+/// Represents a multiline plain-text edit control for the element's raw value,
+/// allowing users to enter a sizeable amount of free-form text.
 ///
+/// <https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element>
 pub fn textarea(
   attrs: List(Attribute(message)),
   content: String,
@@ -865,7 +1216,11 @@ pub fn textarea(
 
 // HTML ELEMENTS: INTERACTIVE ELEMENTS -----------------------------------------
 
+/// Represents a disclosure widget from which the user can obtain additional
+/// information or controls, whose contents are only shown when the element is
+/// toggled into an open state.
 ///
+/// <https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element>
 pub fn details(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -873,7 +1228,10 @@ pub fn details(
   element.element("details", attrs, children)
 }
 
+/// Represents a dialog box or other interactive component, such as a modal
+/// window, an inspector, or a subwindow.
 ///
+/// <https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element>
 pub fn dialog(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -881,7 +1239,11 @@ pub fn dialog(
   element.element("dialog", attrs, children)
 }
 
+/// Represents a summary, caption, or legend for the rest of the contents of its
+/// parent details element, if it has one, and acts as the widget's control for
+/// toggling the details open or closed.
 ///
+/// <https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element>
 pub fn summary(
   attrs: List(Attribute(message)),
   children: List(Element(message)),
@@ -891,7 +1253,11 @@ pub fn summary(
 
 // HTML ELEMENTS: WEB COMPONENTS -----------------------------------------------
 
+/// A placeholder inside a web component's shadow tree that can be filled with
+/// markup by the component's user, letting separate DOM trees be composed
+/// together.
 ///
+/// <https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element>
 pub fn slot(
   attrs: List(Attribute(message)),
   fallback: List(Element(message)),
@@ -899,7 +1265,10 @@ pub fn slot(
   element.element("slot", attrs, fallback)
 }
 
+/// A mechanism for holding HTML fragments that are not rendered when the page
+/// loads but can be cloned and inserted into the document later using script.
 ///
+/// <https://html.spec.whatwg.org/multipage/scripting.html#the-template-element>
 pub fn template(
   attrs: List(Attribute(message)),
   children: List(Element(message)),

--- a/src/lustre/element/keyed.gleam
+++ b/src/lustre/element/keyed.gleam
@@ -137,6 +137,11 @@ pub fn fragment(
 
 // ELEMENTS --------------------------------------------------------------------
 
+/// A _keyed_ variant of `lustre/element/html.ul`. Represents a list of items
+/// where the order is not meaningful, such that rearranging the items would not
+/// materially change the document's meaning.
+///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element>
 pub fn ul(
   attributes: List(Attribute(message)),
   children: List(#(String, Element(message))),
@@ -144,6 +149,11 @@ pub fn ul(
   element("ul", attributes, children)
 }
 
+/// A _keyed_ variant of `lustre/element/html.ol`. Represents a list of items
+/// where the order is meaningful, such that rearranging the items would change
+/// the meaning of the document.
+///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element>
 pub fn ol(
   attributes: List(Attribute(message)),
   children: List(#(String, Element(message))),
@@ -151,6 +161,10 @@ pub fn ol(
   element("ol", attributes, children)
 }
 
+/// A _keyed_ variant of `lustre/element/html.div`. Has no special meaning of
+/// its own; it simply represents its children.
+///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element>
 pub fn div(
   attributes: List(Attribute(message)),
   children: List(#(String, Element(message))),
@@ -158,6 +172,10 @@ pub fn div(
   element("div", attributes, children)
 }
 
+/// A _keyed_ variant of `lustre/element/html.tbody`. Represents a block of rows
+/// that make up the body of data for its parent table element.
+///
+/// <https://html.spec.whatwg.org/multipage/tables.html#the-tbody-element>
 pub fn tbody(
   attributes: List(Attribute(message)),
   children: List(#(String, Element(message))),
@@ -165,6 +183,11 @@ pub fn tbody(
   element("tbody", attributes, children)
 }
 
+/// A _keyed_ variant of `lustre/element/html.dl`. Represents an association
+/// list of zero or more name-value groups, each consisting of terms and their
+/// descriptions.
+///
+/// <https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element>
 pub fn dl(
   attributes: List(Attribute(message)),
   children: List(#(String, Element(message))),


### PR DESCRIPTION
Per the suggestion in #433 I have had Claude AI add in code doc comments to the HTML elements.

I have used https://html.spec.whatwg.org/ as the source for the code comments as I believe this is less problematic in terms of licensing and attribution.

Although the changes were generated by Claude, I have reviewed them.