### PR TITLE
Get rid of empty_list constant

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           otp-version: "27.0"
           rebar3-version: "3"
-          gleam-version: "1.17.0"
+          gleam-version: "1.18.0"
 
       - name: Check formatting
         run: gleam format --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           otp-version: "27.0"
           rebar3-version: "3"
-          gleam-version: "1.17.0"
+          gleam-version: "1.18.0"
 
       - run: |
           version="v$(cat gleam.toml | grep -m 1 "version" | sed -r "s/version *= *\"([[:digit:].]+)\"/\1/")"

--- a/src/lustre/effect.gleam
+++ b/src/lustre/effect.gleam
@@ -76,11 +76,7 @@ import gleam/erlang/process.{type Selector, type Subject}
 
 // CONSTANTS -------------------------------------------------------------------
 
-const empty: Effect(message) = Effect(
-  constants.empty_list,
-  constants.empty_list,
-  constants.empty_list,
-)
+const empty: Effect(message) = Effect([], [], [])
 
 // TYPES -----------------------------------------------------------------------
 
@@ -256,16 +252,16 @@ pub fn select(_sel) {
 /// Provide a context value to child components in the DOM that this Lustre app
 /// didn't render. This occurs in components with that render one or more `<slot>`
 /// elements in their `view` function.
-/// 
+///
 /// Once a value for the given key has been provided, children can [`subscribe`](#subscribe)
 /// to changes and receive updates any subsequent times `provide` is called with
 /// the same key. This facilitates parent-child communication even in cases where
-/// the parent doesn't own the child element directly. 
-/// 
+/// the parent doesn't own the child element directly.
+///
 /// **Note**: This is one half of the WCCG [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md)
 /// and will work in tandem with not just Lustre components but any third-party
 /// Web Component that implements the [`context-request` event](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md#the-context-request-event).
-/// 
+///
 pub fn provide(key: String, value: Json) -> Effect(message) {
   let task = fn(actions: Actions(message)) { actions.provide(key, value) }
 
@@ -277,19 +273,19 @@ pub fn provide(key: String, value: Json) -> Effect(message) {
 /// that has _already provided_ a context for this key at least once. Once a
 /// subscription is set up, any changes to the context value will trigger additional
 /// messages to be dispatched with the new decoded value.
-/// 
+///
 /// If no parent elements have provided a context for the given key at the time
 /// this effect is run, no subscription is set up even if a parent later provides
 /// a context for this key.
-/// 
+///
 /// **Note**: Pay attention to timing and lifecycle differences between applications
 /// and components. Components that need to subscribe to a context should make sure
 /// this effect is called _after_ the component has [connected](./component.html#on_connect).
-/// 
+///
 /// **Note**: This is one half of the WCCG [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md)
 /// and will work in tandem with not just Lustre components and applications, but
 /// any third-party Web Component that acts as a [context provider](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md#context-providers).
-/// 
+///
 pub fn subscribe(key: String, decoder: Decoder(message)) -> Effect(message) {
   let task = fn(actions: Actions(message)) { actions.subscribe(key, decoder) }
 
@@ -298,7 +294,7 @@ pub fn subscribe(key: String, decoder: Decoder(message)) -> Effect(message) {
 
 /// Unsubscribe from a context [`subscription`](#subscribe) that was previously
 /// set up for this key.
-/// 
+///
 pub fn unsubscribe(key: String) -> Effect(message) {
   let task = fn(actions: Actions(message)) { actions.unsubscribe(key) }
 

--- a/src/lustre/element/html.gleam
+++ b/src/lustre/element/html.gleam
@@ -3,7 +3,6 @@
 import gleam/json
 import lustre/attribute.{type Attribute}
 import lustre/element.{type Element, element, namespaced}
-import lustre/internals/constants
 
 // HTML ELEMENTS: MAIN ROOT ----------------------------------------------------
 
@@ -23,7 +22,7 @@ pub fn text(content: String) -> Element(message) {
 
 ///
 pub fn base(attrs: List(Attribute(message))) -> Element(message) {
-  element("base", attrs, constants.empty_list)
+  element("base", attrs, [])
 }
 
 ///
@@ -36,12 +35,12 @@ pub fn head(
 
 ///
 pub fn link(attrs: List(Attribute(message))) -> Element(message) {
-  element("link", attrs, constants.empty_list)
+  element("link", attrs, [])
 }
 
 ///
 pub fn meta(attrs: List(Attribute(message))) -> Element(message) {
-  element("meta", attrs, constants.empty_list)
+  element("meta", attrs, [])
 }
 
 ///
@@ -257,7 +256,7 @@ pub fn figure(
 
 ///
 pub fn hr(attrs: List(Attribute(message))) -> Element(message) {
-  element("hr", attrs, constants.empty_list)
+  element("hr", attrs, [])
 }
 
 ///
@@ -352,7 +351,7 @@ pub fn bdo(
 
 ///
 pub fn br(attrs: List(Attribute(message))) -> Element(message) {
-  element("br", attrs, constants.empty_list)
+  element("br", attrs, [])
 }
 
 ///
@@ -533,14 +532,14 @@ pub fn var(
 
 ///
 pub fn wbr(attrs: List(Attribute(message))) -> Element(message) {
-  element("wbr", attrs, constants.empty_list)
+  element("wbr", attrs, [])
 }
 
 // HTML ELEMENTS: IMAGE AND MULTIMEDIA -----------------------------------------
 
 ///
 pub fn area(attrs: List(Attribute(message))) -> Element(message) {
-  element("area", attrs, constants.empty_list)
+  element("area", attrs, [])
 }
 
 ///
@@ -553,7 +552,7 @@ pub fn audio(
 
 ///
 pub fn img(attrs: List(Attribute(message))) -> Element(message) {
-  element("img", attrs, constants.empty_list)
+  element("img", attrs, [])
 }
 
 /// Used with <area> elements to define an image map (a clickable link area).
@@ -567,7 +566,7 @@ pub fn map(
 
 ///
 pub fn track(attrs: List(Attribute(message))) -> Element(message) {
-  element("track", attrs, constants.empty_list)
+  element("track", attrs, [])
 }
 
 ///
@@ -582,17 +581,17 @@ pub fn video(
 
 ///
 pub fn embed(attrs: List(Attribute(message))) -> Element(message) {
-  element("embed", attrs, constants.empty_list)
+  element("embed", attrs, [])
 }
 
 ///
 pub fn iframe(attrs: List(Attribute(message))) -> Element(message) {
-  element("iframe", attrs, constants.empty_list)
+  element("iframe", attrs, [])
 }
 
 ///
 pub fn object(attrs: List(Attribute(message))) -> Element(message) {
-  element("object", attrs, constants.empty_list)
+  element("object", attrs, [])
 }
 
 ///
@@ -605,12 +604,12 @@ pub fn picture(
 
 ///
 pub fn portal(attrs: List(Attribute(message))) -> Element(message) {
-  element("portal", attrs, constants.empty_list)
+  element("portal", attrs, [])
 }
 
 ///
 pub fn source(attrs: List(Attribute(message))) -> Element(message) {
-  element("source", attrs, constants.empty_list)
+  element("source", attrs, [])
 }
 
 // HTML ELEMENTS: SVG AND MATHML -----------------------------------------------
@@ -635,7 +634,7 @@ pub fn svg(
 
 ///
 pub fn canvas(attrs: List(Attribute(message))) -> Element(message) {
-  element("canvas", attrs, constants.empty_list)
+  element("canvas", attrs, [])
 }
 
 ///
@@ -681,7 +680,7 @@ pub fn caption(
 
 ///
 pub fn col(attrs: List(Attribute(message))) -> Element(message) {
-  element.element("col", attrs, constants.empty_list)
+  element.element("col", attrs, [])
 }
 
 ///
@@ -784,7 +783,7 @@ pub fn form(
 
 ///
 pub fn input(attrs: List(Attribute(message))) -> Element(message) {
-  element.element("input", attrs, constants.empty_list)
+  element.element("input", attrs, [])
 }
 
 ///

--- a/src/lustre/element/keyed.gleam
+++ b/src/lustre/element/keyed.gleam
@@ -55,7 +55,6 @@
 import gleam/list
 import lustre/attribute.{type Attribute}
 import lustre/element.{type Element}
-import lustre/internals/constants
 import lustre/internals/mutable_map.{type MutableMap}
 import lustre/vdom/vnode
 
@@ -177,7 +176,7 @@ pub fn dl(
 fn extract_keyed_children(
   children: List(#(String, Element(message))),
 ) -> #(MutableMap(String, Element(message)), List(Element(message))) {
-  do_extract_keyed_children(children, mutable_map.new(), constants.empty_list)
+  do_extract_keyed_children(children, mutable_map.new(), [])
 }
 
 fn do_extract_keyed_children(

--- a/src/lustre/element/svg.gleam
+++ b/src/lustre/element/svg.gleam
@@ -2,7 +2,6 @@
 
 import lustre/attribute.{type Attribute}
 import lustre/element.{type Element, namespaced, text as inline_text}
-import lustre/internals/constants
 
 // CONSTANTS -------------------------------------------------------------------
 
@@ -22,59 +21,59 @@ pub const namespace = "http://www.w3.org/2000/svg"
 
 ///
 pub fn animate(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "animate", attrs, constants.empty_list)
+  namespaced(namespace, "animate", attrs, [])
 }
 
 ///
 pub fn animate_motion(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "animateMotion", attrs, constants.empty_list)
+  namespaced(namespace, "animateMotion", attrs, [])
 }
 
 ///
 pub fn animate_transform(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "animateTransform", attrs, constants.empty_list)
+  namespaced(namespace, "animateTransform", attrs, [])
 }
 
 ///
 pub fn mpath(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "mpath", attrs, constants.empty_list)
+  namespaced(namespace, "mpath", attrs, [])
 }
 
 ///
 pub fn set(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "set", attrs, constants.empty_list)
+  namespaced(namespace, "set", attrs, [])
 }
 
 // SVG ELEMENTS: BASIC SHAPES --------------------------------------------------
 
 ///
 pub fn circle(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "circle", attrs, constants.empty_list)
+  namespaced(namespace, "circle", attrs, [])
 }
 
 ///
 pub fn ellipse(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "ellipse", attrs, constants.empty_list)
+  namespaced(namespace, "ellipse", attrs, [])
 }
 
 ///
 pub fn line(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "line", attrs, constants.empty_list)
+  namespaced(namespace, "line", attrs, [])
 }
 
 ///
 pub fn polygon(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "polygon", attrs, constants.empty_list)
+  namespaced(namespace, "polygon", attrs, [])
 }
 
 ///
 pub fn polyline(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "polyline", attrs, constants.empty_list)
+  namespaced(namespace, "polyline", attrs, [])
 }
 
 ///
 pub fn rect(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "rect", attrs, constants.empty_list)
+  namespaced(namespace, "rect", attrs, [])
 }
 
 // SVG ELEMENTS: CONTAINER ELEMENTS --------------------------------------------
@@ -205,29 +204,29 @@ pub fn filter(
 
 ///
 pub fn fe_blend(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feBlend", attrs, constants.empty_list)
+  namespaced(namespace, "feBlend", attrs, [])
 }
 
 ///
 pub fn fe_color_matrix(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feColorMatrix", attrs, constants.empty_list)
+  namespaced(namespace, "feColorMatrix", attrs, [])
 }
 
 ///
 pub fn fe_component_transfer(
   attrs: List(Attribute(message)),
 ) -> Element(message) {
-  namespaced(namespace, "feComponentTransfer", attrs, constants.empty_list)
+  namespaced(namespace, "feComponentTransfer", attrs, [])
 }
 
 ///
 pub fn fe_composite(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feComposite", attrs, constants.empty_list)
+  namespaced(namespace, "feComposite", attrs, [])
 }
 
 ///
 pub fn fe_convolve_matrix(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feConvolveMatrix", attrs, constants.empty_list)
+  namespaced(namespace, "feConvolveMatrix", attrs, [])
 }
 
 ///
@@ -242,47 +241,47 @@ pub fn fe_diffuse_lighting(
 pub fn fe_displacement_map(
   attrs: List(Attribute(message)),
 ) -> Element(message) {
-  namespaced(namespace, "feDisplacementMap", attrs, constants.empty_list)
+  namespaced(namespace, "feDisplacementMap", attrs, [])
 }
 
 ///
 pub fn fe_drop_shadow(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feDropShadow", attrs, constants.empty_list)
+  namespaced(namespace, "feDropShadow", attrs, [])
 }
 
 ///
 pub fn fe_flood(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feFlood", attrs, constants.empty_list)
+  namespaced(namespace, "feFlood", attrs, [])
 }
 
 ///
 pub fn fe_func_a(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feFuncA", attrs, constants.empty_list)
+  namespaced(namespace, "feFuncA", attrs, [])
 }
 
 ///
 pub fn fe_func_b(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feFuncB", attrs, constants.empty_list)
+  namespaced(namespace, "feFuncB", attrs, [])
 }
 
 ///
 pub fn fe_func_g(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feFuncG", attrs, constants.empty_list)
+  namespaced(namespace, "feFuncG", attrs, [])
 }
 
 ///
 pub fn fe_func_r(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feFuncR", attrs, constants.empty_list)
+  namespaced(namespace, "feFuncR", attrs, [])
 }
 
 ///
 pub fn fe_gaussian_blur(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feGaussianBlur", attrs, constants.empty_list)
+  namespaced(namespace, "feGaussianBlur", attrs, [])
 }
 
 ///
 pub fn fe_image(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feImage", attrs, constants.empty_list)
+  namespaced(namespace, "feImage", attrs, [])
 }
 
 ///
@@ -295,17 +294,17 @@ pub fn fe_merge(
 
 ///
 pub fn fe_merge_node(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feMergeNode", attrs, constants.empty_list)
+  namespaced(namespace, "feMergeNode", attrs, [])
 }
 
 ///
 pub fn fe_morphology(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feMorphology", attrs, constants.empty_list)
+  namespaced(namespace, "feMorphology", attrs, [])
 }
 
 ///
 pub fn fe_offset(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feOffset", attrs, constants.empty_list)
+  namespaced(namespace, "feOffset", attrs, [])
 }
 
 ///
@@ -326,7 +325,7 @@ pub fn fe_tile(
 
 ///
 pub fn fe_turbulence(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feTurbulence", attrs, constants.empty_list)
+  namespaced(namespace, "feTurbulence", attrs, [])
 }
 
 // SVG ELEMENTS: GRADIENT ELEMENTS ---------------------------------------------
@@ -349,19 +348,19 @@ pub fn radial_gradient(
 
 ///
 pub fn stop(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "stop", attrs, constants.empty_list)
+  namespaced(namespace, "stop", attrs, [])
 }
 
 // SVG ELEMENTS: GRAPHICAL ELEMENTS --------------------------------------------
 
 ///
 pub fn image(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "image", attrs, constants.empty_list)
+  namespaced(namespace, "image", attrs, [])
 }
 
 ///
 pub fn path(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "path", attrs, constants.empty_list)
+  namespaced(namespace, "path", attrs, [])
 }
 
 ///
@@ -374,24 +373,24 @@ pub fn text(
 
 ///
 pub fn use_(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "use", attrs, constants.empty_list)
+  namespaced(namespace, "use", attrs, [])
 }
 
 // SVG ELEMENTS: LIGHTING ELEMENTS ---------------------------------------------
 
 ///
 pub fn fe_distant_light(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feDistantLight", attrs, constants.empty_list)
+  namespaced(namespace, "feDistantLight", attrs, [])
 }
 
 ///
 pub fn fe_point_light(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "fePointLight", attrs, constants.empty_list)
+  namespaced(namespace, "fePointLight", attrs, [])
 }
 
 ///
 pub fn fe_spot_light(attrs: List(Attribute(message))) -> Element(message) {
-  namespaced(namespace, "feSpotLight", attrs, constants.empty_list)
+  namespaced(namespace, "feSpotLight", attrs, [])
 }
 
 // SVG ELEMENTS: NEVER-RENDERED ELEMENTS ---------------------------------------

--- a/src/lustre/event.gleam
+++ b/src/lustre/event.gleam
@@ -52,7 +52,7 @@ pub fn on(name: String, handler: Decoder(message)) -> Attribute(message) {
     handler: decode.map(handler, fn(message) {
       Handler(prevent_default: False, stop_propagation: False, message: message)
     }),
-    include: constants.empty_list,
+    include: [],
     prevent_default: vattr.never,
     stop_propagation: vattr.never,
     debounce: 0,
@@ -81,7 +81,7 @@ pub fn advanced(
   vattr.event(
     name:,
     handler:,
-    include: constants.empty_list,
+    include: [],
     prevent_default: vattr.possible,
     stop_propagation: vattr.possible,
     debounce: 0,

--- a/src/lustre/internals/constants.gleam
+++ b/src/lustre/internals/constants.gleam
@@ -9,10 +9,8 @@
 
 // CONSTRUCTORS ----------------------------------------------------------------
 
-pub const empty_list = []
-
 pub const error_nil = Error(Nil)
 
 pub fn singleton_list(item: a) -> List(a) {
-  [item, ..empty_list]
+  [item, ..[]]
 }

--- a/src/lustre/internals/json_object_builder.gleam
+++ b/src/lustre/internals/json_object_builder.gleam
@@ -5,13 +5,12 @@
 //// the order of our keys, we can just leave the list like it is.
 
 import gleam/json.{type Json}
-import lustre/internals/constants
 
 pub type Builder =
   List(#(String, Json))
 
 pub fn new() -> Builder {
-  constants.empty_list
+  []
 }
 
 pub fn tagged(kind: Int) -> Builder {

--- a/src/lustre/internals/list.ffi.mjs
+++ b/src/lustre/internals/list.ffi.mjs
@@ -2,9 +2,11 @@ import {
   List$NonEmpty,
   List$NonEmpty$rest,
   List$NonEmpty$first,
+  List$Empty,
 } from "../../gleam.mjs";
-import { empty_list } from "./constants.mjs";
 import { append as $list_append } from "../../../gleam_stdlib/gleam/list.mjs";
+
+const empty_list = List$Empty();
 
 export const toList = (arr) =>
   arr.reduceRight((xs, x) => List$NonEmpty(x, xs), empty_list);

--- a/src/lustre/runtime/app.gleam
+++ b/src/lustre/runtime/app.gleam
@@ -6,7 +6,6 @@ import gleam/erlang/process.{type Name}
 import gleam/list
 import gleam/option
 import lustre/effect.{type Effect}
-import lustre/internals/constants
 import lustre/runtime/server/runtime
 import lustre/vdom/vnode.{type Element}
 
@@ -51,22 +50,23 @@ pub type Option(message) {
 
 // CONSTANTS -------------------------------------------------------------------
 
-pub const default_config: Config(message) = Config(
-  open_shadow_root: True,
-  adopt_styles: True,
-  delegates_focus: False,
-  attributes: constants.empty_list,
-  properties: constants.empty_list,
-  contexts: constants.empty_list,
-  is_form_associated: False,
-  on_form_autofill: option.None,
-  on_form_reset: option.None,
-  on_form_restore: option.None,
-  on_form_disabled: option.None,
-  on_connect: option.None,
-  on_adopt: option.None,
-  on_disconnect: option.None,
-)
+pub const default_config: Config(message) =
+  Config(
+    open_shadow_root: True,
+    adopt_styles: True,
+    delegates_focus: False,
+    attributes: [],
+    properties: [],
+    contexts: [],
+    is_form_associated: False,
+    on_form_autofill: option.None,
+    on_form_reset: option.None,
+    on_form_restore: option.None,
+    on_form_disabled: option.None,
+    on_connect: option.None,
+    on_adopt: option.None,
+    on_disconnect: option.None,
+  )
 
 // MANIPULATIONS ---------------------------------------------------------------
 

--- a/src/lustre/runtime/client/runtime.ffi.mjs
+++ b/src/lustre/runtime/client/runtime.ffi.mjs
@@ -1,7 +1,11 @@
 // IMPORTS ---------------------------------------------------------------------
 
-import { Result$isOk, Result$Ok$0, List$isNonEmpty } from "../../../gleam.mjs";
-import { empty_list } from "../../internals/constants.mjs";
+import {
+  Result$isOk,
+  Result$Ok$0,
+  List$Empty,
+  List$isNonEmpty,
+} from "../../../gleam.mjs";
 import { diff } from "../../vdom/diff.mjs";
 import * as Cache from "../../vdom/cache.mjs";
 import { Reconciler } from "../../vdom/reconciler.ffi.mjs";
@@ -11,6 +15,8 @@ import { append, iterate } from "../../internals/list.ffi.mjs";
 import { run as decode } from "../../../../gleam_stdlib/gleam/dynamic/decode.mjs";
 
 //
+
+const empty_list = List$Empty();
 
 export const is_browser = () => !!globalThis.document;
 
@@ -192,7 +198,7 @@ export class Runtime {
           }
         },
         true,
-      )
+      ),
     );
   }
 

--- a/src/lustre/vdom/cache.gleam
+++ b/src/lustre/vdom/cache.gleam
@@ -74,8 +74,8 @@ pub fn new() -> Cache(message) {
     events: new_events(),
     vdoms: mutable_map.new(),
     old_vdoms: mutable_map.new(),
-    dispatched_paths: constants.empty_list,
-    next_dispatched_paths: constants.empty_list,
+    dispatched_paths: [],
+    next_dispatched_paths: [],
   )
 }
 
@@ -95,7 +95,7 @@ pub fn tick(cache: Cache(message)) -> Cache(message) {
     vdoms: mutable_map.new(),
     old_vdoms: cache.vdoms,
     dispatched_paths: cache.next_dispatched_paths,
-    next_dispatched_paths: constants.empty_list,
+    next_dispatched_paths: [],
   )
 }
 

--- a/src/lustre/vdom/diff.gleam
+++ b/src/lustre/vdom/diff.gleam
@@ -51,8 +51,8 @@ pub fn diff(
       //
       node_index: 0,
       patch_index: 0,
-      changes: constants.empty_list,
-      children: constants.empty_list,
+      changes: [],
+      children: [],
       //
       path: path.root,
       cache:,
@@ -352,8 +352,8 @@ fn do_diff(
           removed: 0,
           node_index: 0,
           patch_index: node_index,
-          changes: constants.empty_list,
-          children: constants.empty_list,
+          changes: [],
+          children: [],
           path: path.add(path, node_index, next.key),
           cache:,
           events:,
@@ -401,12 +401,12 @@ fn do_diff(
           events:,
           old: prev.attributes,
           new: next.attributes,
-          added: constants.empty_list,
-          removed: constants.empty_list,
+          added: [],
+          removed: [],
         )
 
       let initial_child_changes = case added_attrs, removed_attrs {
-        [], [] -> constants.empty_list
+        [], [] -> []
         _, _ ->
           constants.singleton_list(patch.update(
             added: added_attrs,
@@ -426,7 +426,7 @@ fn do_diff(
           node_index: 0,
           patch_index: node_index,
           changes: initial_child_changes,
-          children: constants.empty_list,
+          children: [],
           path: child_path,
           cache:,
           events:,
@@ -485,7 +485,7 @@ fn do_diff(
           index: node_index,
           removed: 0,
           changes: constants.singleton_list(patch.replace_text(next.content)),
-          children: constants.empty_list,
+          children: [],
         )
 
       do_diff(
@@ -517,12 +517,12 @@ fn do_diff(
           events:,
           old: prev.attributes,
           new: next.attributes,
-          added: constants.empty_list,
-          removed: constants.empty_list,
+          added: [],
+          removed: [],
         )
 
       let child_changes = case added_attrs, removed_attrs {
-        [], [] -> constants.empty_list
+        [], [] -> []
         _, _ ->
           constants.singleton_list(patch.update(
             added: added_attrs,
@@ -537,10 +537,7 @@ fn do_diff(
 
       let children = case child_changes {
         [] -> children
-        _ -> [
-          patch.new(node_index, 0, child_changes, constants.empty_list),
-          ..children
-        ]
+        _ -> [patch.new(node_index, 0, child_changes, []), ..children]
       }
 
       do_diff(
@@ -577,8 +574,8 @@ fn do_diff(
           removed: 0,
           node_index: 0,
           patch_index: node_index,
-          changes: constants.empty_list,
-          children: constants.empty_list,
+          changes: [],
+          children: [],
           path: path.subtree(child_path),
           cache:,
           events: cache.get_subtree(events, child_key, old_mapper: prev.mapper),

--- a/src/lustre/vdom/patch.gleam
+++ b/src/lustre/vdom/patch.gleam
@@ -1,7 +1,6 @@
 // IMPORTS ---------------------------------------------------------------------
 
 import gleam/json.{type Json}
-import lustre/internals/constants
 import lustre/internals/json_object_builder
 import lustre/vdom/vattr.{type Attribute}
 import lustre/vdom/vnode.{type Element, type Memos}
@@ -13,7 +12,7 @@ import lustre/vdom/vnode.{type Element, type Memos}
 ///
 /// - An `index` which is the index of the node in the real DOM relative to its
 ///   parent's `childNodes` list.
-/// 
+///
 /// - A `path` which represents any additional traversal to get to the relevant
 ///   node. This happens when we have a change deep in the tree and no changes to
 ///   any of the nodes above it. By compressing the path into a single list we can
@@ -80,7 +79,7 @@ pub fn new(
   changes changes: List(Change(message)),
   children children: List(Patch(message)),
 ) -> Patch(message) {
-  Patch(path: constants.empty_list, index:, removed:, changes:, children:)
+  Patch(path: [], index:, removed:, changes:, children:)
 }
 
 pub const replace_text_kind: Int = 0

--- a/src/lustre/vdom/path.gleam
+++ b/src/lustre/vdom/path.gleam
@@ -2,7 +2,6 @@
 
 import gleam/int
 import gleam/string
-import lustre/internals/constants
 
 // CONSTANTS -------------------------------------------------------------------
 
@@ -80,19 +79,19 @@ pub fn subtree(path: Path) -> Path {
 /// This returns a partial path, up to the closest Memo barrier.
 ///
 pub fn event(path: Path, event: String) -> String {
-  do_to_string(False, path, [separator_event, event, ..constants.empty_list])
+  do_to_string(False, path, [separator_event, event, ..[]])
 }
 
 /// Convert a path to a child tree to a resolved string.
 ///
 pub fn child(path: Path) -> String {
-  do_to_string(False, path, constants.empty_list)
+  do_to_string(False, path, [])
 }
 
 /// Convert a path to a full resolved string, including all memo barriers.
 ///
 pub fn to_string(path: Path) -> String {
-  do_to_string(True, path, constants.empty_list)
+  do_to_string(True, path, [])
 }
 
 fn do_to_string(full, path, acc) {

--- a/src/lustre/vdom/vattr.gleam
+++ b/src/lustre/vdom/vattr.gleam
@@ -7,7 +7,6 @@ import gleam/order.{type Order}
 import gleam/string
 import gleam/string_tree.{type StringTree}
 import houdini
-import lustre/internals/constants
 import lustre/internals/json_object_builder
 
 // TYPES -----------------------------------------------------------------------
@@ -100,7 +99,7 @@ pub fn prepare(
       attributes
       // Sort in reverse because `merge` will build the list in reverse anyway.
       |> list.sort(by: fn(a, b) { compare(b, a) })
-      |> merge(constants.empty_list)
+      |> merge([])
   }
 }
 

--- a/src/lustre/vdom/virtualise.ffi.mjs
+++ b/src/lustre/vdom/virtualise.ffi.mjs
@@ -1,10 +1,9 @@
-import { List$NonEmpty } from "../../gleam.mjs";
+import { List$NonEmpty, List$Empty } from "../../gleam.mjs";
 import { text, none, memo, ref, map } from "../element.mjs";
 import { element, namespaced, fragment } from "../element/keyed.mjs";
 import { attribute } from "../attribute.mjs";
 import { insertMetadataChild } from "./reconciler.ffi.mjs";
 import { element_kind, fragment_kind, text_kind, map_kind } from "./vnode.mjs";
-import { empty_list } from "../internals/constants.mjs";
 import {
   ELEMENT_NODE,
   TEXT_NODE,
@@ -143,7 +142,11 @@ const virtualiseFragment = (metaParent, domParent, node, index) => {
 
   const meta = insertMetadataChild(fragment_kind, metaParent, node, index, key);
 
-  const { children, end } = virtualiseChildren(meta, domParent, node.nextSibling);
+  const { children, end } = virtualiseChildren(
+    meta,
+    domParent,
+    node.nextSibling,
+  );
   meta.endNode = end;
 
   const vnode = fragment(toList(children));
@@ -255,6 +258,8 @@ const unescapeKey = (key) => {
     .replace(/&amp;/g, "&")
     .replace(/&#39;/g, "'");
 };
+
+const empty_list = List$Empty();
 
 const toList = (arr) =>
   arr.reduceRight((xs, x) => List$NonEmpty(x, xs), empty_list);


### PR DESCRIPTION
In Gleam 1.18 the compiler started generating a singleton value for the empty list, so this optimisation won't be needed anymore